### PR TITLE
docs: Improve readme with new sections and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ Moov's mission is to give developers an easy way to create and integrate bank pr
 
 Metro2 implements a reader, writer, and validator for consumer credit history reports in an HTTP server and Go library. The HTTP server is available in a [Docker image](#docker) and the Go package `github.com/moov-io/metro2` is available.
 
+## Table of Contents
+
+- [Project Status](#project-status)
+- [Usage](#usage)
+  - As an API
+    - [Docker](#docker)
+    - [Google Cloud](#google-cloud-run)
+    - [Data Persistence](#data-persistence)
+  - [As a Go Module](#go-library)
+  - [As a Command Line Tool](#command-line)
+- [Learn About Metro 2](#learn-about-metro-2)
+- [Getting Help](#getting-help)
+- [Supported and Tested Platforms](#supported-and-tested-platforms)
+- [Contributing](#contributing)
+- [Related Projects](#related-projects)
+
 ## Project Status
 
 Moov Metro2 is actively used in multiple production environments. Please star the project if you are interested in its progress. If you have layers above Metro2 to simplify tasks, perform business operations, or found bugs we would appreciate an issue or pull request. Thanks!
@@ -165,7 +181,10 @@ Global Flags:
       --input string   input file (default is $PWD/metro.json)
 ```
 
-The output parameter represents the full path name for the new metro2 file. The format parameter supports two types, "json" and "metro". The generate parameter will replace new generated trailer record in the file. The input parameter is the source metro2 file to be converted, and can be raw or json.
+- The `output` parameter represents the full path name for the new metro2 file.
+- The `format` parameter determines the output file format and supports "json" or "metro".
+- The `generate` parameter will create a newly generated trailer record in the file.
+- The `input` parameter is the source metro2 file to be converted, and can be raw or json.
 
 Example:
 ```
@@ -188,8 +207,8 @@ Global Flags:
       --input string   input file (default is $PWD/metro.json)
 ```
 
-The format parameter supports two types, "json" and "metro".
-The input parameter is the source metro2 file to be printed, and can be raw or json.
+- The `format` parameter determines the output format and supports "json" or "metro".
+- The `input` parameter is the source metro2 file to be printed, and can be raw or json.
 
 Example:
 ```
@@ -227,7 +246,7 @@ Global Flags:
       --input string   input file (default is $PWD/metro.json)
 ```
 
-The input parameter is the source metro2 file to be validated, and can be raw or json.
+- The `input` parameter is the source metro2 file to be validated, and can be raw or json.
 
 Example:
 ```
@@ -252,7 +271,7 @@ Global Flags:
       --input string   input file (default is $PWD/metro.json)
 ```
 
-The port parameter is the port number for the web service.
+- The `port` parameter is the port number for the web service.
 
 Example:
 ```
@@ -289,14 +308,17 @@ Web page example of the metro2 web server:
 </html>
 ```
 
+## Learn About Metro 2
+- [Intro to Metro 2](https://www.cdiaonline.org/resources/furnishers-of-data-overview/metro2-information/)
+- [Metro 2 File Structure](https://www.collect.org/cv11/Help/metro2format.html)
+
 ## Getting Help
 
  channel | info
  ------- | -------
-  Google Group [moov-users](https://groups.google.com/forum/#!forum/moov-users)| The Moov users Google group is for contributors other people contributing to the Moov project. You can join them without a google account by sending an email to [moov-users+subscribe@googlegroups.com](mailto:moov-users+subscribe@googlegroups.com). After receiving the join-request message, you can simply reply to that to confirm the subscription.
 Twitter [@moov_io](https://twitter.com/moov_io)	| You can follow Moov.IO's Twitter feed to get updates on our project(s). You can also tweet us questions or just share blogs or stories.
-[GitHub Issue](https://github.com/moov-io/metro2/issues) | If you are able to reproduce a problem please open a GitHub Issue under the specific project that caused the error.
-[moov-io slack](https://slack.moov.io/) | Join our slack channel (`#metro2`) to have an interactive discussion about the development of the project.
+[GitHub Issue](https://github.com/moov-io) | If you are able to reproduce a problem please open a GitHub Issue under the specific project that caused the error.
+[moov-io slack](https://slack.moov.io/) | Join our slack channel to have an interactive discussion about the development of the project.
 
 ## Supported and Tested Platforms
 
@@ -304,10 +326,35 @@ Twitter [@moov_io](https://twitter.com/moov_io)	| You can follow Moov.IO's Twitt
 
 ## Contributing
 
-Yes please! Please review our [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](https://github.com/moov-io/ach/blob/master/CODE_OF_CONDUCT.md) to get started! [Checkout our issues](https://github.com/moov-io/metro2/issues) for something to help out with.
+Yes please! Please review our [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) to get started!
 
-This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) and uses Go 1.14 or higher. See [Golang's install instructions](https://golang.org/doc/install) for help setting up Go. You can download the source code and we offer [tagged and released versions](https://github.com/moov-io/metro2/releases/latest) as well. We highly recommend you use a tagged release for production.
+This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) and uses Go v1.14 or higher. See [Golang's install instructions](https://golang.org/doc/install) for help setting up Go. You can download the source code and we offer [tagged and released versions](https://github.com/moov-io/metro2/releases/latest) as well. We highly recommend you use a tagged release for production.
+
+### Releasing
+
+To make a release of metro2 simply open a pull request with `CHANGELOG.md` and `version.go` updated with the next version number and details. You'll also need to push the tag (i.e. `git push origin v1.0.0`) to origin in order for CI to make the release.
+
+### Testing
+
+We maintain a comprehensive suite of unit tests and recommend table-driven testing when a particular function warrants several very similar test cases. To run all test files in the current directory, use `go test`. Current overall coverage can be found on [Codecov](https://app.codecov.io/gh/moov-io/metro2/).
+
+### Fuzzing
+
+We currently run fuzzing over ImageCashLetter in the form of a [`moov/metro2`](https://hub.docker.com/r/moov/metro2fuzz) Docker image. You can [read more](./test/fuzz-reader/README.md) or run the image and report crasher examples to [`security@moov.io`](mailto:security@moov.io). Thanks!
+
+## Related Projects
+As part of Moov's initiative to offer open source fintech infrastructure, we have a large collection of active projects you may find useful:
+
+- [Moov Watchman](https://github.com/moov-io/watchman) offers search functions over numerous trade sanction lists from the United States and European Union.
+
+- [Moov Fed](https://github.com/moov-io/fed) implements utility services for searching the United States Federal Reserve System such as ABA routing numbers, financial institution name lookup, and FedACH and Fedwire routing information.
+
+- [Moov Wire](https://github.com/moov-io/wire) implements an interface to write files for the Fedwire Funds Service, a real-time gross settlement funds transfer system operated by the United States Federal Reserve Banks.
+
+- [Moov ACH](https://github.com/moov-io/ach) provides ACH file generation and parsing, supporting all Standard Entry Codes for the primary method of money movement throughout the United States.
+
+- [Moov Image Cash Letter](https://github.com/moov-io/imagecashletter) implements Image Cash Letter (ICL) files used for Check21, X.9 or check truncation files for exchange and remote deposit in the U.S.
 
 ## License
 
-Apache License 2.0 See [LICENSE](LICENSE) for details.
+Apache License 2.0 - See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,37 @@
-# metro2
+[![Moov Banner Logo](https://user-images.githubusercontent.com/20115216/104214617-885b3c80-53ec-11eb-8ce0-9fc745fb5bfc.png)](https://github.com/moov-io)
+
+<p align="center">
+  <a href="https://moov-io.github.io/metro2/">Project Documentation</a>
+  ·
+  <a href="https://moov-io.github.io/metro2/api/#overview">API Endpoints</a>
+  ·
+  <a href="https://slack.moov.io/">Community</a>
+  ·
+  <a href="https://moov.io/blog/">Blog</a>
+  <br>
+  <br>
+</p>
 
 [![GoDoc](https://godoc.org/github.com/moov-io/metro2?status.svg)](https://godoc.org/github.com/moov-io/metro2)
 [![Build Status](https://github.com/moov-io/metro2/workflows/Go/badge.svg)](https://github.com/moov-io/metro2/actions)
 [![Coverage Status](https://codecov.io/gh/moov-io/metro2/branch/master/graph/badge.svg)](https://codecov.io/gh/moov-io/metro2)
 [![Go Report Card](https://goreportcard.com/badge/github.com/moov-io/metro2)](https://goreportcard.com/report/github.com/moov-io/metro2)
-[![Apache 2 licensed](https://img.shields.io/badge/license-Apache2-blue.svg)](https://raw.githubusercontent.com/moov-io/metro2/master/LICENSE)
+[![Repo Size](https://img.shields.io/github/languages/code-size/moov-io/metro2?label=project%20size)](https://github.com/moov-io/metro2)
+[![Apache 2 License](https://img.shields.io/badge/license-Apache2-blue.svg)](https://raw.githubusercontent.com/moov-io/metro2/master/LICENSE)
+[![Slack Channel](https://slack.moov.io/badge.svg?bg=e01563&fgColor=fffff)](https://slack.moov.io/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/moov/metro2)](https://hub.docker.com/r/moov/metro2)
+[![GitHub Stars](https://img.shields.io/github/stars/moov-io/metro2)](https://github.com/moov-io/metro2)
+[![Twitter](https://img.shields.io/twitter/follow/moov_io?style=social)](https://twitter.com/moov_io?lang=en)
+
+# moov-io/metro2
+
+Moov's mission is to give developers an easy way to create and integrate bank processing into their own software products. Our open source projects are each focused on solving a single responsibility in financial services and designed around performance, scalability, and ease-of-use.
 
 Metro2 implements a reader, writer, and validator for consumer credit history reports in an HTTP server and Go library. The HTTP server is available in a [Docker image](#docker) and the Go package `github.com/moov-io/metro2` is available.
 
-Docs: [API Endpoints](https://moov-io.github.io/metro2/api/)
+## Project Status
 
-## Getting Started
+Moov Metro2 is actively used in multiple production environments. Please star the project if you are interested in its progress. If you have layers above Metro2 to simplify tasks, perform business operations, or found bugs we would appreciate an issue or pull request. Thanks!
 
 ### Docker
 


### PR DESCRIPTION
- Added a header, table of contents, related projects, and a couple useful resources
- Added a Google Cloud setup tutorial
- Miscellaneous minor changes

Side note - we could potentially move the command line examples (starting from line 167) to a separate file to cut down on readme length.

