### PR TITLE
Fix J1 & J2 validation for missing/empty generationCode

### DIFF
--- a/pkg/lib/j1_segment.go
+++ b/pkg/lib/j1_segment.go
@@ -159,7 +159,7 @@ func (s *J1Segment) Length() int {
 func (s *J1Segment) ValidateGenerationCode() error {
 	switch s.GenerationCode {
 	case GenerationCodeJunior, GenerationCodeSenior, GenerationCode2, GenerationCode3, GenerationCode4,
-		GenerationCode5, GenerationCode6, GenerationCode7, GenerationCode8, GenerationCode9:
+		GenerationCode5, GenerationCode6, GenerationCode7, GenerationCode8, GenerationCode9, "":
 		return nil
 	}
 	return utils.NewErrInvalidValueOfField("generation code", "j1 segment")

--- a/pkg/lib/j1_segment_test.go
+++ b/pkg/lib/j1_segment_test.go
@@ -6,6 +6,8 @@ package lib
 
 import (
 	"bytes"
+	"encoding/json"
+
 	"gopkg.in/check.v1"
 )
 
@@ -24,6 +26,26 @@ func (t *SegmentTest) TestJ1SegmentWithInvalidData(c *check.C) {
 	segment := NewJ1Segment()
 	_, err := segment.Parse(append([]byte("ERROR"), t.sampleJ1Segment...))
 	c.Assert(err, check.Not(check.IsNil))
+}
+
+func (t *SegmentTest) TestJ1SegmentWithEmptyGenerationCode(c *check.C) {
+	jsonStr := `{
+      "segmentIdentifier": "J1",
+      "surname": "BEAUCHAMP",
+      "firstName": "KEVIN",
+      "socialSecurityNumber": 445112877,
+      "dateBirth": "2020-01-02T00:00:00Z",
+      "telephoneNumber": 4335552333,
+      "ecoaCode": "2",
+      "consumerInformationIndicator": "R"
+    }`
+	segment := NewJ1Segment()
+	err := json.Unmarshal([]byte(jsonStr), &segment)
+	c.Assert(err, check.IsNil)
+	err = segment.Validate()
+	c.Assert(err, check.IsNil)
+	c.Assert(segment.Name(), check.Equals, J1SegmentName)
+	c.Assert(segment.Length(), check.Equals, J1SegmentLength)
 }
 
 func (t *SegmentTest) TestJ1SegmentWithInvalidGenerationCode(c *check.C) {

--- a/pkg/lib/j2_segment.go
+++ b/pkg/lib/j2_segment.go
@@ -215,10 +215,10 @@ func (s *J2Segment) Length() int {
 func (s *J2Segment) ValidateGenerationCode() error {
 	switch s.GenerationCode {
 	case GenerationCodeJunior, GenerationCodeSenior, GenerationCode2, GenerationCode3, GenerationCode4,
-		GenerationCode5, GenerationCode6, GenerationCode7, GenerationCode8, GenerationCode9:
+		GenerationCode5, GenerationCode6, GenerationCode7, GenerationCode8, GenerationCode9, "":
 		return nil
 	}
-	return utils.NewErrInvalidValueOfField("generation code", "j1 segment")
+	return utils.NewErrInvalidValueOfField("generation code", "j2 segment")
 }
 
 // validation of telephone number

--- a/pkg/lib/j2_segment_test.go
+++ b/pkg/lib/j2_segment_test.go
@@ -6,6 +6,8 @@ package lib
 
 import (
 	"bytes"
+	"encoding/json"
+
 	"gopkg.in/check.v1"
 )
 
@@ -33,7 +35,35 @@ func (t *SegmentTest) TestJ2SegmentWithInvalidGenerationCode(c *check.C) {
 	segment.GenerationCode = "0"
 	err = segment.Validate()
 	c.Assert(err, check.Not(check.IsNil))
-	c.Assert(err.Error(), check.DeepEquals, "generation code in j1 segment has an invalid value")
+	c.Assert(err.Error(), check.DeepEquals, "generation code in j2 segment has an invalid value")
+}
+
+func (t *SegmentTest) TestJ2SegmentWithEmptyGenerationCode(c *check.C) {
+	jsonStr := `{
+      "segmentIdentifier": "J2",
+      "surname": "BEAUCHAMP",
+      "firstName": "KEVIN",
+      "socialSecurityNumber": 445112877,
+      "dateBirth": "2020-01-02T00:00:00Z",
+      "telephoneNumber": 4335552333,
+      "ecoaCode": "2",
+      "consumerInformationIndicator": "R",
+      "countryCode": "US",
+      "firstLineAddress": "234 HARRISON PLACE",
+      "secondLineAddress": "SUITE #305",
+      "city": "LANSING",
+      "state": "MI",
+      "zipCode": "72654",
+      "addressIndicator": "Y",
+      "residenceCode": "O"
+    }`
+	segment := NewJ2Segment()
+	err := json.Unmarshal([]byte(jsonStr), &segment)
+	c.Assert(err, check.IsNil)
+	err = segment.Validate()
+	c.Assert(err, check.IsNil)
+	c.Assert(segment.Name(), check.Equals, J2SegmentName)
+	c.Assert(segment.Length(), check.Equals, J2SegmentLength)
 }
 
 func (t *SegmentTest) TestJ2SegmentWithInvalidTelephoneNumber(c *check.C) {


### PR DESCRIPTION
## What does this PR do?
Fixes issue where if `generationCode` is missing in `json` data, the validation fails. Generation Code is not required (just applicable), so the validation should not fail. Also fixes a typo in `j2` validation (it said `j1` when it printed out an error).

- [x] Added tests covering the case
- I've seen the `""` used in `ValidateTermsFrequency`, so I've used the same instead of defining a new constant (e.g. `GenerationCodeEmpty`)


I've went through the `CONTRIBUTING.md`. It mentions to `AUTHORS.md`, but that gives 404. It seems like the file got deleted along the way.

My Golang knowledge is fairly minimal, I will be happy to make updates as required.

Thank you for your work!