### PR TITLE
Fix newIdentificationNumber on L1 segment [WIP]

### DIFF
--- a/pkg/lib/l1_segment.go
+++ b/pkg/lib/l1_segment.go
@@ -33,7 +33,7 @@ type L1Segment struct {
 	// Contains the new Identification Number assigned to this account.
 	// Do not include embedded blanks or special characters.
 	// If field 2 = 1, this field should be blank filled.
-	NewIdentificationNumber string `json:"balloonPaymentDueDate,omitempty"`
+	NewIdentificationNumber string `json:"newIdentificationNumber,omitempty"`
 
 	converter
 	validator


### PR DESCRIPTION
it looks like the newIdentificationNumber field in API is named incorrectly because of typo or bad copy-paste.

I'm not sure how to regenerate client code, though, `make client` changes a lot of files in pkg, but not `pkg/client/model_l1_segment.go`, for example. Suggestions?

Also, there's a question of backwards compatibility in case someone already used `balloonPaymentDueDate` for that field already.