### PR TITLE
fix: add validation for account status, account type, and special comment code

### DIFF
--- a/pkg/lib/base_segment.go
+++ b/pkg/lib/base_segment.go
@@ -924,6 +924,19 @@ func (r *BaseSegment) ValidateDateBirth() error {
 	return nil
 }
 
+// validation of account status
+func (r *BaseSegment) ValidateAccountStatus() error {
+	switch r.AccountStatus {
+	case AccountStatusDF, AccountStatusDA, AccountStatus11, AccountStatus61, AccountStatus62,
+		AccountStatus63, AccountStatus64, AccountStatus71, AccountStatus78, AccountStatus80,
+		AccountStatus82, AccountStatus83, AccountStatus84, AccountStatus93, AccountStatus96,
+		AccountStatus97, AccountStatus05, AccountStatus13, AccountStatus65, AccountStatus88,
+		AccountStatus89, AccountStatus94, AccountStatus95:
+		return nil
+	}
+	return utils.NewErrInvalidValueOfField("account status", "base segment")
+}
+
 // Name returns name of packed base segment
 func (r *PackedBaseSegment) Name() string {
 	return PackedBaseSegmentName
@@ -1376,6 +1389,19 @@ func (r *PackedBaseSegment) ValidateDateBirth() error {
 		return utils.NewErrInvalidValueOfField("date birth", "base segment")
 	}
 	return nil
+}
+
+// validation of account status
+func (r *PackedBaseSegment) ValidateAccountStatus() error {
+	switch r.AccountStatus {
+	case AccountStatusDF, AccountStatusDA, AccountStatus11, AccountStatus61, AccountStatus62,
+		AccountStatus63, AccountStatus64, AccountStatus71, AccountStatus78, AccountStatus80,
+		AccountStatus82, AccountStatus83, AccountStatus84, AccountStatus93, AccountStatus96,
+		AccountStatus97, AccountStatus05, AccountStatus13, AccountStatus65, AccountStatus88,
+		AccountStatus89, AccountStatus94, AccountStatus95:
+		return nil
+	}
+	return utils.NewErrInvalidValueOfField("account status", "packed base segment")
 }
 
 func readApplicableSegments(record []byte, f Record) (int, error) {

--- a/pkg/lib/base_segment.go
+++ b/pkg/lib/base_segment.go
@@ -954,6 +954,26 @@ func (r *BaseSegment) ValidateAccountType() error {
 	return utils.NewErrInvalidValueOfField("account type", "base segment")
 }
 
+// validation of special comment
+func (r *BaseSegment) ValidateSpecialComment() error {
+	switch r.SpecialComment {
+	case SpecialCommentCodeBlank, SpecialCommentCodeB, SpecialCommentCodeC, SpecialCommentCodeH, SpecialCommentCodeI,
+		SpecialCommentCodeM, SpecialCommentCodeO, SpecialCommentCodeS, SpecialCommentCodeV, SpecialCommentCodeAB,
+		SpecialCommentCodeAC, SpecialCommentCodeAH, SpecialCommentCodeAI, SpecialCommentCodeAM, SpecialCommentCodeAN,
+		SpecialCommentCodeAO, SpecialCommentCodeAP, SpecialCommentCodeAS, SpecialCommentCodeAT, SpecialCommentCodeAU,
+		SpecialCommentCodeAV, SpecialCommentCodeAW, SpecialCommentCodeAX, SpecialCommentCodeAZ, SpecialCommentCodeBA,
+		SpecialCommentCodeBB, SpecialCommentCodeBC, SpecialCommentCodeBD, SpecialCommentCodeBE, SpecialCommentCodeBF,
+		SpecialCommentCodeBG, SpecialCommentCodeBH, SpecialCommentCodeBI, SpecialCommentCodeBJ, SpecialCommentCodeBK,
+		SpecialCommentCodeBL, SpecialCommentCodeBN, SpecialCommentCodeBO, SpecialCommentCodeBP, SpecialCommentCodeBS,
+		SpecialCommentCodeBT, SpecialCommentCodeCH, SpecialCommentCodeCI, SpecialCommentCodeCJ, SpecialCommentCodeCK,
+		SpecialCommentCodeCL, SpecialCommentCodeCM, SpecialCommentCodeCN, SpecialCommentCodeCO, SpecialCommentCodeCP,
+		SpecialCommentCodeCS, SpecialCommentCodeDE:
+
+		return nil
+	}
+	return utils.NewErrInvalidValueOfField("special comment", "base segment")
+}
+
 // Name returns name of packed base segment
 func (r *PackedBaseSegment) Name() string {
 	return PackedBaseSegmentName
@@ -1436,6 +1456,26 @@ func (r *PackedBaseSegment) ValidateAccountType() error {
 		return nil
 	}
 	return utils.NewErrInvalidValueOfField("account type", "packed base segment")
+}
+
+// validation of special comment
+func (r *PackedBaseSegment) ValidateSpecialComment() error {
+	switch r.SpecialComment {
+	case SpecialCommentCodeBlank, SpecialCommentCodeB, SpecialCommentCodeC, SpecialCommentCodeH, SpecialCommentCodeI,
+		SpecialCommentCodeM, SpecialCommentCodeO, SpecialCommentCodeS, SpecialCommentCodeV, SpecialCommentCodeAB,
+		SpecialCommentCodeAC, SpecialCommentCodeAH, SpecialCommentCodeAI, SpecialCommentCodeAM, SpecialCommentCodeAN,
+		SpecialCommentCodeAO, SpecialCommentCodeAP, SpecialCommentCodeAS, SpecialCommentCodeAT, SpecialCommentCodeAU,
+		SpecialCommentCodeAV, SpecialCommentCodeAW, SpecialCommentCodeAX, SpecialCommentCodeAZ, SpecialCommentCodeBA,
+		SpecialCommentCodeBB, SpecialCommentCodeBC, SpecialCommentCodeBD, SpecialCommentCodeBE, SpecialCommentCodeBF,
+		SpecialCommentCodeBG, SpecialCommentCodeBH, SpecialCommentCodeBI, SpecialCommentCodeBJ, SpecialCommentCodeBK,
+		SpecialCommentCodeBL, SpecialCommentCodeBN, SpecialCommentCodeBO, SpecialCommentCodeBP, SpecialCommentCodeBS,
+		SpecialCommentCodeBT, SpecialCommentCodeCH, SpecialCommentCodeCI, SpecialCommentCodeCJ, SpecialCommentCodeCK,
+		SpecialCommentCodeCL, SpecialCommentCodeCM, SpecialCommentCodeCN, SpecialCommentCodeCO, SpecialCommentCodeCP,
+		SpecialCommentCodeCS, SpecialCommentCodeDE:
+
+		return nil
+	}
+	return utils.NewErrInvalidValueOfField("special comment", "packed base segment")
 }
 
 func readApplicableSegments(record []byte, f Record) (int, error) {

--- a/pkg/lib/base_segment.go
+++ b/pkg/lib/base_segment.go
@@ -937,6 +937,23 @@ func (r *BaseSegment) ValidateAccountStatus() error {
 	return utils.NewErrInvalidValueOfField("account status", "base segment")
 }
 
+// validation of account type
+func (r *BaseSegment) ValidateAccountType() error {
+	switch r.AccountType {
+	case AccountType00, AccountType01, AccountType02, AccountType03, AccountType04, AccountType05, AccountType06,
+		AccountType07, AccountType08, AccountType0A, AccountType0C, AccountType0F, AccountType0G, AccountType10,
+		AccountType11, AccountType12, AccountType13, AccountType15, AccountType17, AccountType18, AccountType19,
+		AccountType20, AccountType25, AccountType26, AccountType29, AccountType2A, AccountType2C, AccountType37,
+		AccountType3A, AccountType43, AccountType47, AccountType48, AccountType4D, AccountType50, AccountType5A,
+		AccountType5B, AccountType65, AccountType66, AccountType67, AccountType68, AccountType69, AccountType6A,
+		AccountType6B, AccountType6D, AccountType70, AccountType71, AccountType72, AccountType73, AccountType74,
+		AccountType75, AccountType77, AccountType7A, AccountType7B, AccountType89, AccountType8A, AccountType8B,
+		AccountType90, AccountType91, AccountType92, AccountType93, AccountType95, AccountType9A, AccountType9B:
+		return nil
+	}
+	return utils.NewErrInvalidValueOfField("account type", "base segment")
+}
+
 // Name returns name of packed base segment
 func (r *PackedBaseSegment) Name() string {
 	return PackedBaseSegmentName
@@ -1402,6 +1419,23 @@ func (r *PackedBaseSegment) ValidateAccountStatus() error {
 		return nil
 	}
 	return utils.NewErrInvalidValueOfField("account status", "packed base segment")
+}
+
+// validation of account type
+func (r *PackedBaseSegment) ValidateAccountType() error {
+	switch r.AccountType {
+	case AccountType00, AccountType01, AccountType02, AccountType03, AccountType04, AccountType05, AccountType06,
+		AccountType07, AccountType08, AccountType0A, AccountType0C, AccountType0F, AccountType0G, AccountType10,
+		AccountType11, AccountType12, AccountType13, AccountType15, AccountType17, AccountType18, AccountType19,
+		AccountType20, AccountType25, AccountType26, AccountType29, AccountType2A, AccountType2C, AccountType37,
+		AccountType3A, AccountType43, AccountType47, AccountType48, AccountType4D, AccountType50, AccountType5A,
+		AccountType5B, AccountType65, AccountType66, AccountType67, AccountType68, AccountType69, AccountType6A,
+		AccountType6B, AccountType6D, AccountType70, AccountType71, AccountType72, AccountType73, AccountType74,
+		AccountType75, AccountType77, AccountType7A, AccountType7B, AccountType89, AccountType8A, AccountType8B,
+		AccountType90, AccountType91, AccountType92, AccountType93, AccountType95, AccountType9A, AccountType9B:
+		return nil
+	}
+	return utils.NewErrInvalidValueOfField("account type", "packed base segment")
 }
 
 func readApplicableSegments(record []byte, f Record) (int, error) {

--- a/pkg/lib/base_segment_test.go
+++ b/pkg/lib/base_segment_test.go
@@ -466,3 +466,23 @@ func (t *SegmentTest) TestPackedBaseSegmentWithDateBirth(c *check.C) {
 	err = segment.Validate()
 	c.Assert(err, check.Not(check.IsNil))
 }
+
+func (t *SegmentTest) TestBaseSegmentWithInvalidSpecialComment(c *check.C) {
+	segment := &BaseSegment{}
+	_, err := segment.Parse(t.sampleBaseSegment)
+	c.Assert(err, check.IsNil)
+	segment.SpecialComment = "FF"
+	err = segment.Validate()
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(err.Error(), check.DeepEquals, "special comment in base segment has an invalid value")
+}
+
+func (t *SegmentTest) TestPackedBaseSegmentWithInvalidSpecialComment(c *check.C) {
+	segment := &PackedBaseSegment{}
+	_, err := segment.Parse(t.samplePackedBaseSegment)
+	c.Assert(err, check.IsNil)
+	segment.SpecialComment = "FF"
+	err = segment.Validate()
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(err.Error(), check.DeepEquals, "special comment in packed base segment has an invalid value")
+}

--- a/pkg/lib/base_segment_test.go
+++ b/pkg/lib/base_segment_test.go
@@ -419,6 +419,26 @@ func (t *SegmentTest) TestPackedBaseSegmentWithInvalidAccountStatus(c *check.C) 
 	c.Assert(err.Error(), check.DeepEquals, "account status in packed base segment has an invalid value")
 }
 
+func (t *SegmentTest) TestBaseSegmentWithInvalidAccountType(c *check.C) {
+	segment := &BaseSegment{}
+	_, err := segment.Parse(t.sampleBaseSegment)
+	c.Assert(err, check.IsNil)
+	segment.AccountType = "FF"
+	err = segment.Validate()
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(err.Error(), check.DeepEquals, "account type in base segment has an invalid value")
+}
+
+func (t *SegmentTest) TestPackedBaseSegmentWithInvalidAccountType(c *check.C) {
+	segment := &PackedBaseSegment{}
+	_, err := segment.Parse(t.samplePackedBaseSegment)
+	c.Assert(err, check.IsNil)
+	segment.AccountType = "FF"
+	err = segment.Validate()
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(err.Error(), check.DeepEquals, "account type in packed base segment has an invalid value")
+}
+
 func (t *SegmentTest) TestPackedBaseSegmentWithSocialSecurityNumber(c *check.C) {
 	segment := &PackedBaseSegment{}
 	_, err := segment.Parse(t.samplePackedBaseSegment)

--- a/pkg/lib/base_segment_test.go
+++ b/pkg/lib/base_segment_test.go
@@ -399,6 +399,26 @@ func (t *SegmentTest) TestBaseSegmentWithDateBirth(c *check.C) {
 	c.Assert(err, check.Not(check.IsNil))
 }
 
+func (t *SegmentTest) TestBaseSegmentWithInvalidAccountStatus(c *check.C) {
+	segment := &BaseSegment{}
+	_, err := segment.Parse(t.sampleBaseSegment)
+	c.Assert(err, check.IsNil)
+	segment.AccountStatus = "FF"
+	err = segment.Validate()
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(err.Error(), check.DeepEquals, "account status in base segment has an invalid value")
+}
+
+func (t *SegmentTest) TestPackedBaseSegmentWithInvalidAccountStatus(c *check.C) {
+	segment := &PackedBaseSegment{}
+	_, err := segment.Parse(t.samplePackedBaseSegment)
+	c.Assert(err, check.IsNil)
+	segment.AccountStatus = "FF"
+	err = segment.Validate()
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(err.Error(), check.DeepEquals, "account status in packed base segment has an invalid value")
+}
+
 func (t *SegmentTest) TestPackedBaseSegmentWithSocialSecurityNumber(c *check.C) {
 	segment := &PackedBaseSegment{}
 	_, err := segment.Parse(t.samplePackedBaseSegment)

--- a/pkg/lib/constants.go
+++ b/pkg/lib/constants.go
@@ -381,6 +381,110 @@ const (
 	AccountType9A = "9A"
 	// Account Type 9B
 	AccountType9B = "9B"
+	// Special Comment Code Blank
+	SpecialCommentCodeBlank = ""
+	// Special Comment Code B
+	SpecialCommentCodeB = "B"
+	// Special Comment Code C
+	SpecialCommentCodeC = "C"
+	// Special Comment Code H
+	SpecialCommentCodeH = "H"
+	// Special Comment Code I
+	SpecialCommentCodeI = "I"
+	// Special Comment Code M
+	SpecialCommentCodeM = "M"
+	// Special Comment Code O
+	SpecialCommentCodeO = "O"
+	// Special Comment Code S
+	SpecialCommentCodeS = "S"
+	// Special Comment Code V
+	SpecialCommentCodeV = "V"
+	// Special Comment Code AB
+	SpecialCommentCodeAB = "AB"
+	// Special Comment Code AC
+	SpecialCommentCodeAC = "AC"
+	// Special Comment Code AH
+	SpecialCommentCodeAH = "AH"
+	// Special Comment Code AI
+	SpecialCommentCodeAI = "AI"
+	// Special Comment Code AM
+	SpecialCommentCodeAM = "AM"
+	// Special Comment Code AN
+	SpecialCommentCodeAN = "AN"
+	// Special Comment Code AO
+	SpecialCommentCodeAO = "AO"
+	// Special Comment Code AP
+	SpecialCommentCodeAP = "AP"
+	// Special Comment Code AS
+	SpecialCommentCodeAS = "AS"
+	// Special Comment Code AT
+	SpecialCommentCodeAT = "AT"
+	// Special Comment Code AU
+	SpecialCommentCodeAU = "AU"
+	// Special Comment Code AV
+	SpecialCommentCodeAV = "AV"
+	// Special Comment Code AW
+	SpecialCommentCodeAW = "AW"
+	// Special Comment Code AX
+	SpecialCommentCodeAX = "AX"
+	// Special Comment Code AZ
+	SpecialCommentCodeAZ = "AZ"
+	// Special Comment Code BA
+	SpecialCommentCodeBA = "BA"
+	// Special Comment Code BB
+	SpecialCommentCodeBB = "BB"
+	// Special Comment Code BC
+	SpecialCommentCodeBC = "BC"
+	// Special Comment Code BD
+	SpecialCommentCodeBD = "BD"
+	// Special Comment Code BE
+	SpecialCommentCodeBE = "BE"
+	// Special Comment Code BF
+	SpecialCommentCodeBF = "BF"
+	// Special Comment Code BG
+	SpecialCommentCodeBG = "BG"
+	// Special Comment Code BH
+	SpecialCommentCodeBH = "BH"
+	// Special Comment Code BI
+	SpecialCommentCodeBI = "BI"
+	// Special Comment Code BJ
+	SpecialCommentCodeBJ = "BJ"
+	// Special Comment Code BK
+	SpecialCommentCodeBK = "BK"
+	// Special Comment Code BL
+	SpecialCommentCodeBL = "BL"
+	// Special Comment Code BN
+	SpecialCommentCodeBN = "BN"
+	// Special Comment Code BO
+	SpecialCommentCodeBO = "BO"
+	// Special Comment Code BP
+	SpecialCommentCodeBP = "BP"
+	// Special Comment Code BS
+	SpecialCommentCodeBS = "BS"
+	// Special Comment Code BT
+	SpecialCommentCodeBT = "BT"
+	// Special Comment Code CH
+	SpecialCommentCodeCH = "CH"
+	// Special Comment Code CI
+	SpecialCommentCodeCI = "CI"
+	// Special Comment Code CJ
+	SpecialCommentCodeCJ = "CJ"
+	// Special Comment Code CK
+	SpecialCommentCodeCK = "CK"
+	// Special Comment Code CL
+	SpecialCommentCodeCL = "CL"
+	// Special Comment Code CM
+	SpecialCommentCodeCM = "CM"
+	// Special Comment Code CN
+	SpecialCommentCodeCN = "CN"
+	// Special Comment Code CO
+	SpecialCommentCodeCO = "CO"
+	// Special Comment Code CP
+	SpecialCommentCodeCP = "CP"
+	// Special Comment Code CS
+	SpecialCommentCodeCS = "CS"
+	// Special Comment Code DE
+	SpecialCommentCodeDE = "DE"
 )
 
 // Internal Constants

--- a/pkg/lib/constants.go
+++ b/pkg/lib/constants.go
@@ -255,6 +255,132 @@ const (
 	SpecializedDeferredPayment = 2
 	// ECOA Code Z
 	ECOACodeZ = "Z"
+	// Account Type 00
+	AccountType00 = "00"
+	// Account Type 01
+	AccountType01 = "01"
+	// Account Type 02
+	AccountType02 = "02"
+	// Account Type 03
+	AccountType03 = "03"
+	// Account Type 04
+	AccountType04 = "04"
+	// Account Type 05
+	AccountType05 = "05"
+	// Account Type 06
+	AccountType06 = "06"
+	// Account Type 07
+	AccountType07 = "07"
+	// Account Type 08
+	AccountType08 = "08"
+	// Account Type 0A
+	AccountType0A = "0A"
+	// Account Type 0C
+	AccountType0C = "0C"
+	// Account Type 0F
+	AccountType0F = "0F"
+	// Account Type 0G
+	AccountType0G = "0G"
+	// Account Type 10
+	AccountType10 = "10"
+	// Account Type 11
+	AccountType11 = "11"
+	// Account Type 12
+	AccountType12 = "12"
+	// Account Type 13
+	AccountType13 = "13"
+	// Account Type 15
+	AccountType15 = "15"
+	// Account Type 17
+	AccountType17 = "17"
+	// Account Type 18
+	AccountType18 = "18"
+	// Account Type 19
+	AccountType19 = "19"
+	// Account Type 20
+	AccountType20 = "20"
+	// Account Type 25
+	AccountType25 = "25"
+	// Account Type 26
+	AccountType26 = "26"
+	// Account Type 29
+	AccountType29 = "29"
+	// Account Type 2A
+	AccountType2A = "2A"
+	// Account Type 2C
+	AccountType2C = "2C"
+	// Account Type 37
+	AccountType37 = "37"
+	// Account Type 3A
+	AccountType3A = "3A"
+	// Account Type 43
+	AccountType43 = "43"
+	// Account Type 47
+	AccountType47 = "47"
+	// Account Type 48
+	AccountType48 = "48"
+	// Account Type 4D
+	AccountType4D = "4D"
+	// Account Type 50
+	AccountType50 = "50"
+	// Account Type 5A
+	AccountType5A = "5A"
+	// Account Type 5B
+	AccountType5B = "5B"
+	// Account Type 65
+	AccountType65 = "65"
+	// Account Type 66
+	AccountType66 = "66"
+	// Account Type 67
+	AccountType67 = "67"
+	// Account Type 68
+	AccountType68 = "68"
+	// Account Type 69
+	AccountType69 = "69"
+	// Account Type 6A
+	AccountType6A = "6A"
+	// Account Type 6B
+	AccountType6B = "6B"
+	// Account Type 6D
+	AccountType6D = "6D"
+	// Account Type 70
+	AccountType70 = "70"
+	// Account Type 71
+	AccountType71 = "71"
+	// Account Type 72
+	AccountType72 = "72"
+	// Account Type 73
+	AccountType73 = "73"
+	// Account Type 74
+	AccountType74 = "74"
+	// Account Type 75
+	AccountType75 = "75"
+	// Account Type 77
+	AccountType77 = "77"
+	// Account Type 7A
+	AccountType7A = "7A"
+	// Account Type 7B
+	AccountType7B = "7B"
+	// Account Type 89
+	AccountType89 = "89"
+	// Account Type 8A
+	AccountType8A = "8A"
+	// Account Type 8B
+	AccountType8B = "8B"
+	// Account Type 90
+	AccountType90 = "90"
+	// Account Type 91
+	AccountType91 = "91"
+	// Account Type 92
+	AccountType92 = "92"
+	// Account Type 93
+	AccountType93 = "93"
+	// Account Type 95
+	AccountType95 = "95"
+	// Account Type 9A
+	AccountType9A = "9A"
+	// Account Type 9B
+	AccountType9B = "9B"
 )
 
 // Internal Constants


### PR DESCRIPTION
Adds `BaseSegment` validation for `AccountStatus`, `AccountType`, and `SpecialComment` fields. Resolves #191 