### PR TITLE
Morgana future/refactor/eliminate base segment/packed base segment code duplication

### DIFF
--- a/pkg/file/file_instance.go
+++ b/pkg/file/file_instance.go
@@ -23,6 +23,17 @@ import (
 
 var _ File = (*fileInstance)(nil)
 
+// baseSegmentData provides access to base segment fields for trailer generation.
+// Both BaseSegment and PackedBaseSegment implement this interface through baseSegmentCore.
+type baseSegmentData interface {
+	lib.Record
+	GetSocialSecurityNumber() int
+	GetDateBirth() *utils.Time
+	GetECOACode() string
+	GetTelephoneNumber() int64
+	GetAccountStatus() string
+}
+
 // File contains the structures of a parsed metro 2 file.
 type fileInstance struct {
 	Header  lib.Record   `json:"header"`
@@ -96,16 +107,13 @@ func (f *fileInstance) GeneratorTrailer() (lib.Record, error) {
 
 	if f.format == utils.PackedFileFormat {
 		trailer = lib.NewPackedTrailerRecord()
-		information, err = f.generatorPackedTrailer()
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		trailer = lib.NewTrailerRecord()
-		information, err = f.generatorTrailer()
-		if err != nil {
-			return nil, err
-		}
+	}
+
+	information, err = f.generatorTrailer()
+	if err != nil {
+		return nil, err
 	}
 
 	fromFields := reflect.ValueOf(information).Elem()
@@ -159,17 +167,9 @@ func (f *fileInstance) Validate() error {
 		}
 	}
 
-	var information *lib.TrailerInformation
-	if f.format == utils.PackedFileFormat {
-		information, err = f.generatorPackedTrailer()
-		if err != nil {
-			return err
-		}
-	} else {
-		information, err = f.generatorTrailer()
-		if err != nil {
-			return err
-		}
+	information, err := f.generatorTrailer()
+	if err != nil {
+		return err
 	}
 
 	fromFields := reflect.ValueOf(information).Elem()
@@ -487,70 +487,39 @@ func (f *fileInstance) SetType(newType string) error {
 	return nil
 }
 
+// generatorTrailer generates trailer information from all base segments.
+// Works with both BaseSegment and PackedBaseSegment through the baseSegmentData interface.
 func (f *fileInstance) generatorTrailer() (*lib.TrailerInformation, error) {
 	trailer := &lib.TrailerInformation{}
-
 	trailer.TotalBaseRecords = len(f.Bases)
 	trailer.BlockCount = len(f.Bases) + 2
+
 	for _, base := range f.Bases {
-		baseSegment, ok := base.(*lib.BaseSegment)
-		if !ok && baseSegment.Validate() != nil {
-			return nil, utils.NewErrInvalidSegment(baseSegment.Name())
-		}
-
-		if isValidSocialSecurityNumber(baseSegment.SocialSecurityNumber) {
-			trailer.TotalSocialNumbersAllSegments++
-			trailer.TotalSocialNumbersBaseSegments++
-		}
-
-		if !baseSegment.DateBirth.IsZero() {
-			trailer.TotalDatesBirthAllSegments++
-			trailer.TotalDatesBirthBaseSegments++
-		}
-
-		if baseSegment.ECOACode == lib.ECOACodeZ {
-			trailer.TotalECOACodeZ++
-		}
-		if baseSegment.TelephoneNumber > 0 {
-			trailer.TotalTelephoneNumbersAllSegments++
-		}
-		f.statisticAccountStatus(baseSegment.AccountStatus, trailer)
-		f.statisticBase(baseSegment, trailer)
-	}
-
-	return trailer, nil
-}
-
-func (f *fileInstance) generatorPackedTrailer() (*lib.TrailerInformation, error) {
-	trailer := &lib.TrailerInformation{}
-	trailer.TotalBaseRecords = len(f.Bases)
-	trailer.BlockCount = len(f.Bases) + 2
-	for _, base := range f.Bases {
-		base, ok := base.(*lib.PackedBaseSegment)
-		if !ok && base.Validate() != nil {
+		segment, ok := base.(baseSegmentData)
+		if !ok {
 			return nil, utils.NewErrInvalidSegment(base.Name())
 		}
 
-		if isValidSocialSecurityNumber(base.SocialSecurityNumber) {
+		if isValidSocialSecurityNumber(segment.GetSocialSecurityNumber()) {
 			trailer.TotalSocialNumbersAllSegments++
 			trailer.TotalSocialNumbersBaseSegments++
 		}
 
-		if !base.DateBirth.IsZero() {
+		if !segment.GetDateBirth().IsZero() {
 			trailer.TotalDatesBirthAllSegments++
 			trailer.TotalDatesBirthBaseSegments++
 		}
 
-		if base.ECOACode == lib.ECOACodeZ {
+		if segment.GetECOACode() == lib.ECOACodeZ {
 			trailer.TotalECOACodeZ++
 		}
 
-		if base.TelephoneNumber > 0 {
+		if segment.GetTelephoneNumber() > 0 {
 			trailer.TotalTelephoneNumbersAllSegments++
 		}
 
-		f.statisticAccountStatus(base.AccountStatus, trailer)
-		f.statisticPackedBase(base, trailer)
+		f.statisticAccountStatus(segment.GetAccountStatus(), trailer)
+		f.statisticBase(segment, trailer)
 	}
 
 	return trailer, nil
@@ -607,120 +576,9 @@ func (f *fileInstance) statisticAccountStatus(status string, info *lib.TrailerIn
 	}
 }
 
-func (f *fileInstance) statisticPackedBase(base *lib.PackedBaseSegment, trailer *lib.TrailerInformation) {
-	for _, j1 := range base.GetSegments(lib.J1SegmentName) {
-		sub, ok := j1.(*lib.J1Segment)
-		if !ok {
-			continue
-		}
-		if sub.ECOACode == lib.ECOACodeZ {
-			trailer.TotalECOACodeZ++
-		}
-		if sub.Validate() == nil {
-			trailer.TotalConsumerSegmentsJ1++
-
-			if isValidSocialSecurityNumber(sub.SocialSecurityNumber) {
-				trailer.TotalSocialNumbersAllSegments++
-				trailer.TotalSocialNumbersJ1Segments++
-			}
-
-			if !sub.DateBirth.IsZero() {
-				trailer.TotalDatesBirthAllSegments++
-				trailer.TotalDatesBirthJ1Segments++
-			}
-
-			if sub.TelephoneNumber > 0 {
-				trailer.TotalTelephoneNumbersAllSegments++
-			}
-		}
-	}
-	for _, j2 := range base.GetSegments(lib.J2SegmentName) {
-		sub, ok := j2.(*lib.J2Segment)
-		if !ok {
-			continue
-		}
-		if sub.ECOACode == lib.ECOACodeZ {
-			trailer.TotalECOACodeZ++
-		}
-		if sub.Validate() == nil {
-			trailer.TotalConsumerSegmentsJ2++
-
-			if isValidSocialSecurityNumber(sub.SocialSecurityNumber) {
-				trailer.TotalSocialNumbersAllSegments++
-				trailer.TotalSocialNumbersJ2Segments++
-			}
-
-			if !sub.DateBirth.IsZero() {
-				trailer.TotalDatesBirthAllSegments++
-				trailer.TotalDatesBirthJ2Segments++
-			}
-
-			if sub.TelephoneNumber > 0 {
-				trailer.TotalTelephoneNumbersAllSegments++
-			}
-		}
-	}
-	for _, k1 := range base.GetSegments(lib.K1SegmentName) {
-		sub, ok := k1.(*lib.K1Segment)
-		if !ok {
-			continue
-		}
-		if len(sub.OriginalCreditorName) > 0 {
-			trailer.TotalOriginalCreditorSegments++
-		}
-	}
-	for _, k2 := range base.GetSegments(lib.K2SegmentName) {
-		sub, ok := k2.(*lib.K2Segment)
-		if !ok {
-			continue
-		}
-		if sub.PurchasedIndicator == lib.PurchasedIndicatorToName ||
-			sub.PurchasedIndicator == lib.PurchasedIndicatorFromName {
-			trailer.TotalPurchasedToSegments++
-		}
-	}
-	for _, k3 := range base.GetSegments(lib.K3SegmentName) {
-		sub, ok := k3.(*lib.K3Segment)
-		if !ok {
-			continue
-		}
-		if sub.AgencyIdentifier == lib.AgencyIdentifierNotApplicable {
-			trailer.TotalMortgageInformationSegments++
-		}
-	}
-	for _, k4 := range base.GetSegments(lib.K4SegmentName) {
-		sub, ok := k4.(*lib.K4Segment)
-		if !ok {
-			continue
-		}
-		if sub.SpecializedPaymentIndicator == lib.SpecializedBalloonPayment ||
-			sub.SpecializedPaymentIndicator == lib.SpecializedDeferredPayment {
-			trailer.TotalPaymentInformationSegments++
-		}
-	}
-	for _, l1 := range base.GetSegments(lib.L1SegmentName) {
-		sub, ok := l1.(*lib.L1Segment)
-		if !ok {
-			continue
-		}
-		if sub.ChangeIndicator == lib.ChangeIndicatorAccountNumber ||
-			sub.ChangeIndicator == lib.ChangeIndicatorIdentificationNumber ||
-			sub.ChangeIndicator == lib.ChangeIndicatorBothNumber {
-			trailer.TotalChangeSegments++
-		}
-	}
-	for _, n1 := range base.GetSegments(lib.N1SegmentName) {
-		sub, ok := n1.(*lib.N1Segment)
-		if !ok {
-			continue
-		}
-		if len(sub.EmployerName) > 0 {
-			trailer.TotalEmploymentSegments++
-		}
-	}
-}
-
-func (f *fileInstance) statisticBase(base *lib.BaseSegment, trailer *lib.TrailerInformation) {
+// statisticBase collects statistics from base segment's sub-segments (J1, J2, K1-K4, L1, N1).
+// Works with both BaseSegment and PackedBaseSegment through the lib.Record interface.
+func (f *fileInstance) statisticBase(base lib.Record, trailer *lib.TrailerInformation) {
 	for _, j1 := range base.GetSegments(lib.J1SegmentName) {
 		sub, ok := j1.(*lib.J1Segment)
 		if !ok {

--- a/pkg/lib/base_segment.go
+++ b/pkg/lib/base_segment.go
@@ -839,6 +839,16 @@ func (r *baseSegmentCore) unmarshalApplicableSegment(description string, data []
 	return r.AddApplicableSegment(segment)
 }
 
+// Getter methods for baseSegmentCore fields.
+// These are used by external packages (like file) that need to access
+// base segment data through interfaces without knowing the concrete type.
+
+func (r *baseSegmentCore) GetSocialSecurityNumber() int    { return r.SocialSecurityNumber }
+func (r *baseSegmentCore) GetDateBirth() *utils.Time       { return &r.DateBirth }
+func (r *baseSegmentCore) GetECOACode() string             { return r.ECOACode }
+func (r *baseSegmentCore) GetTelephoneNumber() int64       { return r.TelephoneNumber }
+func (r *baseSegmentCore) GetAccountStatus() string        { return r.AccountStatus }
+
 // customized field validation functions
 // function name should be "Validate" + field name
 // These methods are defined on baseSegmentCore to be shared between

--- a/pkg/lib/base_segment.go
+++ b/pkg/lib/base_segment.go
@@ -20,8 +20,10 @@ var _ Segment = (*BaseSegment)(nil)
 var _ Record = (*PackedBaseSegment)(nil)
 var _ Segment = (*PackedBaseSegment)(nil)
 
-// BaseSegment holds the base segment
-type BaseSegment struct {
+// baseSegmentCore contains all shared data fields and methods for both
+// character and packed base segment formats. This eliminates code duplication
+// between BaseSegment and PackedBaseSegment.
+type baseSegmentCore struct {
 	// Contains a value equal to the length of the block of data and must be reported when using the packed format or
 	// when reporting variable length records.  This value includes the four bytes reserved for this field.
 	// Report the standard IBM variable record length conventions.
@@ -505,10 +507,17 @@ type BaseSegment struct {
 	validator
 }
 
-// PackedBaseSegment holds the packed base segment
-type PackedBaseSegment BaseSegment
+// BaseSegment holds the base segment (character format)
+type BaseSegment struct {
+	baseSegmentCore
+}
 
-type baseJson BaseSegment
+// PackedBaseSegment holds the packed base segment
+type PackedBaseSegment struct {
+	baseSegmentCore
+}
+
+type baseJson baseSegmentCore
 
 type dataRecordJson struct {
 	Base       baseJson  `json:"base,omitempty"`
@@ -533,8 +542,8 @@ func (r *BaseSegment) Parse(record []byte, isVariableLength bool) (int, error) {
 		return 0, utils.NewErrSegmentLength("base segment")
 	}
 
-	fields := reflect.ValueOf(r).Elem()
-	length, err := r.parseRecordValues(fields, baseSegmentCharacterFormat, record, &r.validator, "base segment", isVariableLength)
+	fields := reflect.ValueOf(&r.baseSegmentCore).Elem()
+	length, err := r.parseRecordValues(fields, baseSegmentCharacterFormat, record, &r.baseSegmentCore.validator, "base segment", isVariableLength)
 	if err != nil {
 		return length, err
 	}
@@ -571,7 +580,7 @@ func (r *BaseSegment) Parse(record []byte, isVariableLength bool) (int, error) {
 func (r *BaseSegment) String() string {
 	var buf strings.Builder
 	specifications := r.toSpecifications(baseSegmentCharacterFormat)
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.baseSegmentCore).Elem()
 	blockSize := r.RecordDescriptorWord
 	buf.Grow(blockSize)
 	for _, spec := range specifications {
@@ -620,7 +629,7 @@ func (r *BaseSegment) Bytes() []byte {
 
 // Validate performs some checks on the record and returns an error if not Validated
 func (r *BaseSegment) Validate() error {
-	if err := r.validateRecord(r, baseSegmentCharacterFormat, "base segment"); err != nil {
+	if err := r.validateRecord(&r.baseSegmentCore, baseSegmentCharacterFormat, "base segment"); err != nil {
 		return err
 	}
 	return nil
@@ -637,7 +646,7 @@ func (r *BaseSegment) Length() int {
 }
 
 // GetSegments returns list of applicable segments by segment name
-func (r *BaseSegment) GetSegments(name string) []Segment {
+func (r *baseSegmentCore) GetSegments(name string) []Segment {
 	var ret []Segment
 	switch name {
 	case J1SegmentName:
@@ -681,7 +690,7 @@ func (r *BaseSegment) GetSegments(name string) []Segment {
 }
 
 // AddApplicableSegment will add new applicable segment into record
-func (r *BaseSegment) AddApplicableSegment(s Segment) error {
+func (r *baseSegmentCore) AddApplicableSegment(s Segment) error {
 	err := s.Validate()
 	if err != nil {
 		return err
@@ -713,7 +722,7 @@ func (r *BaseSegment) MarshalJSON() ([]byte, error) {
 	dummy := dataRecordJson{}
 	base := baseJson{}
 
-	fromFields := reflect.ValueOf(r).Elem()
+	fromFields := reflect.ValueOf(&r.baseSegmentCore).Elem()
 	toFields := reflect.ValueOf(&base).Elem()
 	for i := 0; i < fromFields.NumField(); i++ {
 		fieldName := fromFields.Type().Field(i).Name
@@ -762,7 +771,7 @@ func (r *BaseSegment) UnmarshalJSON(data []byte) error {
 			}
 
 			fromFields := reflect.ValueOf(&base).Elem()
-			toFields := reflect.ValueOf(r).Elem()
+			toFields := reflect.ValueOf(&r.baseSegmentCore).Elem()
 			for i := 0; i < fromFields.NumField(); i++ {
 				fieldName := fromFields.Type().Field(i).Name
 				fromField := fromFields.FieldByName(fieldName)
@@ -801,9 +810,11 @@ func (r *BaseSegment) UnmarshalJSON(data []byte) error {
 
 // customized field validation functions
 // function name should be "Validate" + field name
+// These methods are defined on baseSegmentCore to be shared between
+// BaseSegment and PackedBaseSegment, eliminating code duplication.
 
 // validation of identification number
-func (r *BaseSegment) ValidateIdentificationNumber() error {
+func (r *baseSegmentCore) ValidateIdentificationNumber() error {
 	if validFilledString(r.IdentificationNumber) {
 		return utils.NewErrInvalidValueOfField("identification number", "base segment")
 	}
@@ -811,7 +822,7 @@ func (r *BaseSegment) ValidateIdentificationNumber() error {
 }
 
 // validation of portfolio type
-func (r *BaseSegment) ValidatePortfolioType() error {
+func (r *baseSegmentCore) ValidatePortfolioType() error {
 	switch r.PortfolioType {
 	case PortfolioTypeCredit, PortfolioTypeInstallment, PortfolioTypeMortgage, PortfolioTypeOpen, PortfolioTypeRevolving:
 		return nil
@@ -820,7 +831,7 @@ func (r *BaseSegment) ValidatePortfolioType() error {
 }
 
 // validation of terms duration
-func (r *BaseSegment) ValidateTermsDuration() error {
+func (r *baseSegmentCore) ValidateTermsDuration() error {
 	switch r.TermsDuration {
 	case TermsDurationCredit, TermsDurationOpen, TermsDurationRevolving:
 		return nil
@@ -833,7 +844,7 @@ func (r *BaseSegment) ValidateTermsDuration() error {
 }
 
 // validation of terms frequency
-func (r *BaseSegment) ValidateTermsFrequency() error {
+func (r *baseSegmentCore) ValidateTermsFrequency() error {
 	switch r.TermsFrequency {
 	case TermsFrequencyDeferred, TermsFrequencyPayment, TermsFrequencyWeekly, TermsFrequencyBiweekly,
 		TermsFrequencySemimonthly, TermsFrequencyMonthly, TermsFrequencyBimonthly, TermsFrequencyQuarterly,
@@ -844,7 +855,7 @@ func (r *BaseSegment) ValidateTermsFrequency() error {
 }
 
 // validation of payment rating
-func (r *BaseSegment) ValidatePaymentRating() error {
+func (r *baseSegmentCore) ValidatePaymentRating() error {
 	switch r.AccountStatus {
 	case AccountStatus05, AccountStatus13, AccountStatus65, AccountStatus88, AccountStatus89, AccountStatus94, AccountStatus95:
 		switch r.PaymentRating {
@@ -862,7 +873,7 @@ func (r *BaseSegment) ValidatePaymentRating() error {
 }
 
 // validation of payment history profile
-func (r *BaseSegment) ValidatePaymentHistoryProfile() error {
+func (r *baseSegmentCore) ValidatePaymentHistoryProfile() error {
 	if len(r.PaymentHistoryProfile) != 24 {
 		return utils.NewErrInvalidValueOfField("payment history profile", "base segment")
 	}
@@ -881,7 +892,7 @@ func (r *BaseSegment) ValidatePaymentHistoryProfile() error {
 }
 
 // validation of interest type indicator
-func (r *BaseSegment) ValidateInterestTypeIndicator() error {
+func (r *baseSegmentCore) ValidateInterestTypeIndicator() error {
 	switch r.InterestTypeIndicator {
 	case InterestIndicatorFixed, InterestIndicatorVariable, "":
 		return nil
@@ -890,7 +901,7 @@ func (r *BaseSegment) ValidateInterestTypeIndicator() error {
 }
 
 // validation of telephone number
-func (r *BaseSegment) ValidateTelephoneNumber() error {
+func (r *baseSegmentCore) ValidateTelephoneNumber() error {
 	if err := r.isPhoneNumber(r.TelephoneNumber, "base segment"); err != nil {
 		return err
 	}
@@ -898,7 +909,7 @@ func (r *BaseSegment) ValidateTelephoneNumber() error {
 }
 
 // validation of social security number
-func (r *BaseSegment) ValidateSocialSecurityNumber() error {
+func (r *baseSegmentCore) ValidateSocialSecurityNumber() error {
 	if r.SocialSecurityNumber == 0 && r.DateBirth.IsZero() {
 		// social security number and date birth may omit for business account
 		if r.ECOACode == "2" || r.ECOACode == "5" {
@@ -910,7 +921,7 @@ func (r *BaseSegment) ValidateSocialSecurityNumber() error {
 }
 
 // validation of date of birth
-func (r *BaseSegment) ValidateDateBirth() error {
+func (r *baseSegmentCore) ValidateDateBirth() error {
 	if r.SocialSecurityNumber == 0 && r.DateBirth.IsZero() {
 		// social security number and date birth may omit for business account
 		if r.ECOACode == "2" || r.ECOACode == "5" {
@@ -922,7 +933,7 @@ func (r *BaseSegment) ValidateDateBirth() error {
 }
 
 // validation of account status
-func (r *BaseSegment) ValidateAccountStatus() error {
+func (r *baseSegmentCore) ValidateAccountStatus() error {
 	switch r.AccountStatus {
 	case AccountStatusDF, AccountStatusDA, AccountStatus11, AccountStatus61, AccountStatus62,
 		AccountStatus63, AccountStatus64, AccountStatus71, AccountStatus78, AccountStatus80,
@@ -935,7 +946,7 @@ func (r *BaseSegment) ValidateAccountStatus() error {
 }
 
 // validation of account type
-func (r *BaseSegment) ValidateAccountType() error {
+func (r *baseSegmentCore) ValidateAccountType() error {
 	switch r.AccountType {
 	case AccountType00, AccountType01, AccountType02, AccountType03, AccountType04, AccountType05, AccountType06,
 		AccountType07, AccountType08, AccountType0A, AccountType0C, AccountType0F, AccountType0G, AccountType10,
@@ -952,7 +963,7 @@ func (r *BaseSegment) ValidateAccountType() error {
 }
 
 // validation of special comment
-func (r *BaseSegment) ValidateSpecialComment() error {
+func (r *baseSegmentCore) ValidateSpecialComment() error {
 	switch r.SpecialComment {
 	case SpecialCommentCodeBlank, SpecialCommentCodeB, SpecialCommentCodeC, SpecialCommentCodeH, SpecialCommentCodeI,
 		SpecialCommentCodeM, SpecialCommentCodeO, SpecialCommentCodeS, SpecialCommentCodeV, SpecialCommentCodeAB,
@@ -982,7 +993,7 @@ func (r *PackedBaseSegment) Parse(record []byte, isVariableLength bool) (int, er
 		return 0, utils.NewErrSegmentLength("packed base segment")
 	}
 
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.baseSegmentCore).Elem()
 	offset := 0
 	for i := 0; i < fields.NumField(); i++ {
 		fieldName := fields.Type().Field(i).Name
@@ -1050,7 +1061,7 @@ func (r *PackedBaseSegment) Parse(record []byte, isVariableLength bool) (int, er
 func (r *PackedBaseSegment) String() string {
 	var buf strings.Builder
 	specifications := r.toSpecifications(baseSegmentPackedFormat)
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.baseSegmentCore).Elem()
 	blockSize := r.RecordDescriptorWord
 	if r.BlockDescriptorWord > 0 {
 		blockSize += 4
@@ -1102,7 +1113,7 @@ func (r *PackedBaseSegment) Bytes() []byte {
 
 // Validate performs some checks on the record and returns an error if not Validated
 func (r *PackedBaseSegment) Validate() error {
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.baseSegmentCore).Elem()
 	for i := 0; i < fields.NumField(); i++ {
 		fieldName := fields.Type().Field(i).Name
 		if spec, ok := baseSegmentPackedFormat[fieldName]; ok {
@@ -1115,7 +1126,7 @@ func (r *PackedBaseSegment) Validate() error {
 		}
 
 		funcName := r.validateFuncName(fieldName)
-		method := reflect.ValueOf(r).MethodByName(funcName)
+		method := reflect.ValueOf(&r.baseSegmentCore).MethodByName(funcName)
 		if method.IsValid() {
 			response := method.Call(nil) //nolint:forbidigo
 			if len(response) == 0 {
@@ -1141,84 +1152,14 @@ func (r *PackedBaseSegment) Length() int {
 	return r.RecordDescriptorWord
 }
 
-// GetSegments returns list of applicable segments by segment name
-func (r *PackedBaseSegment) GetSegments(name string) []Segment {
-	var ret []Segment
-	switch name {
-	case J1SegmentName:
-		return r.j1Segments
-	case J2SegmentName:
-		return r.j2Segments
-	case K1SegmentName:
-		if r.k1Segment == nil {
-			return nil
-		}
-		ret = append(ret, r.k1Segment)
-	case K2SegmentName:
-		if r.k2Segment == nil {
-			return nil
-		}
-		ret = append(ret, r.k2Segment)
-	case K3SegmentName:
-		if r.k3Segment == nil {
-			return nil
-		}
-		ret = append(ret, r.k3Segment)
-	case K4SegmentName:
-		if r.k4Segment == nil {
-			return nil
-		}
-		ret = append(ret, r.k4Segment)
-	case L1SegmentName:
-		if r.l1Segment == nil {
-			return nil
-		}
-		ret = append(ret, r.l1Segment)
-	case N1SegmentName:
-		if r.n1Segment == nil {
-			return nil
-		}
-		ret = append(ret, r.n1Segment)
-	default:
-		return nil
-	}
-	return ret
-}
-
-// AddApplicableSegment will add new applicable segment into record
-func (r *PackedBaseSegment) AddApplicableSegment(s Segment) error {
-	err := s.Validate()
-	if err != nil {
-		return err
-	}
-	switch s.Name() {
-	case J1SegmentName:
-		r.j1Segments = append(r.j1Segments, s)
-	case J2SegmentName:
-		r.j2Segments = append(r.j2Segments, s)
-	case K1SegmentName:
-		r.k1Segment = s
-	case K2SegmentName:
-		r.k2Segment = s
-	case K3SegmentName:
-		r.k3Segment = s
-	case K4SegmentName:
-		r.k4Segment = s
-	case L1SegmentName:
-		r.l1Segment = s
-	case N1SegmentName:
-		r.n1Segment = s
-	}
-
-	return nil
-}
+// GetSegments and AddApplicableSegment are inherited from baseSegmentCore
 
 // MarshalJSON returns JSON blob
 func (r *PackedBaseSegment) MarshalJSON() ([]byte, error) {
 	dummy := dataRecordJson{}
 	base := baseJson{}
 
-	fromFields := reflect.ValueOf(r).Elem()
+	fromFields := reflect.ValueOf(&r.baseSegmentCore).Elem()
 	toFields := reflect.ValueOf(&base).Elem()
 	for i := 0; i < fromFields.NumField(); i++ {
 		fieldName := fromFields.Type().Field(i).Name
@@ -1266,7 +1207,7 @@ func (r *PackedBaseSegment) UnmarshalJSON(data []byte) error {
 				return fmt.Errorf("unabled to parse %s segment (%s)", key, parseErr.Error())
 			}
 			fromFields := reflect.ValueOf(&base).Elem()
-			toFields := reflect.ValueOf(r).Elem()
+			toFields := reflect.ValueOf(&r.baseSegmentCore).Elem()
 			for i := 0; i < fromFields.NumField(); i++ {
 				fieldName := fromFields.Type().Field(i).Name
 				fromField := fromFields.FieldByName(fieldName)
@@ -1302,177 +1243,7 @@ func (r *PackedBaseSegment) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// customized field validation functions
-// function name should be "Validate" + field name
-
-// validation of identification number
-func (r *PackedBaseSegment) ValidateIdentificationNumber() error {
-	if validFilledString(r.IdentificationNumber) {
-		return utils.NewErrInvalidValueOfField("identification number", "packed base segment")
-	}
-	return nil
-}
-
-// validation of portfolio type
-func (r *PackedBaseSegment) ValidatePortfolioType() error {
-	switch r.PortfolioType {
-	case PortfolioTypeCredit, PortfolioTypeInstallment, PortfolioTypeMortgage, PortfolioTypeOpen, PortfolioTypeRevolving:
-		return nil
-	}
-	return utils.NewErrInvalidValueOfField("portfolio type", "packed base segment")
-}
-
-// validation of terms duration
-func (r *PackedBaseSegment) ValidateTermsDuration() error {
-	switch r.TermsDuration {
-	case TermsDurationCredit, TermsDurationOpen, TermsDurationRevolving:
-		return nil
-	}
-	_, err := strconv.Atoi(r.TermsDuration)
-	if err != nil {
-		return utils.NewErrInvalidValueOfField("terms duration", "packed base segment")
-	}
-	return nil
-}
-
-// validation of terms frequency
-func (r *PackedBaseSegment) ValidateTermsFrequency() error {
-	switch r.TermsFrequency {
-	case TermsFrequencyDeferred, TermsFrequencyPayment, TermsFrequencyWeekly, TermsFrequencyBiweekly,
-		TermsFrequencySemimonthly, TermsFrequencyMonthly, TermsFrequencyBimonthly, TermsFrequencyQuarterly,
-		TermsFrequencyTriAnnually, TermsFrequencySemiannually, TermsFrequencyAnnually, "":
-		return nil
-	}
-	return utils.NewErrInvalidValueOfField("terms frequency", "packed base segment")
-}
-
-// validation of payment rating
-func (r *PackedBaseSegment) ValidatePaymentRating() error {
-	switch r.AccountStatus {
-	case AccountStatus05, AccountStatus13, AccountStatus65, AccountStatus88, AccountStatus89, AccountStatus94, AccountStatus95:
-		switch r.PaymentRating {
-		case PaymentRatingCurrent, PaymentRatingPast30, PaymentRatingPast60, PaymentRatingPast90,
-			PaymentRatingPast120, PaymentRatingPast150, PaymentRatingPast180, PaymentRatingCollection, PaymentRatingChargeOff:
-			return nil
-		}
-		return utils.NewErrInvalidValueOfField("payment rating", "packed base segment")
-	}
-
-	if r.PaymentRating == "" {
-		return nil
-	}
-	return utils.NewErrInvalidValueOfField("payment rating", "packed base segment")
-}
-
-// validation of payment history profile
-func (r *PackedBaseSegment) ValidatePaymentHistoryProfile() error {
-	if len(r.PaymentHistoryProfile) != 24 {
-		return utils.NewErrInvalidValueOfField("payment history profile", "packed base segment")
-	}
-	for i := 0; i < len(r.PaymentHistoryProfile); i++ {
-		switch r.PaymentHistoryProfile[i] {
-		case PaymentHistoryPast0, PaymentHistoryPast30, PaymentHistoryPast60, PaymentHistoryPast90,
-			PaymentHistoryPast120, PaymentHistoryPast150, PaymentHistoryPast180, PaymentHistoryNoPayment,
-			PaymentHistoryNoPaymentMonth, PaymentHistoryZero, PaymentHistoryCollection,
-			PaymentHistoryForeclosureCompleted, PaymentHistoryVoluntarySurrender, PaymentHistoryRepossession,
-			PaymentHistoryChargeOff, PaymentHistoryNoHistory:
-			continue
-		}
-		return utils.NewErrInvalidValueOfField("payment history profile", "packed base segment")
-	}
-	return nil
-}
-
-// validation of interest type indicator
-func (r *PackedBaseSegment) ValidateInterestTypeIndicator() error {
-	switch r.InterestTypeIndicator {
-	case InterestIndicatorFixed, InterestIndicatorVariable, "":
-		return nil
-	}
-	return utils.NewErrInvalidValueOfField("interest type indicator", "packed base segment")
-}
-
-// validation of telephone number
-func (r *PackedBaseSegment) ValidateTelephoneNumber() error {
-	if err := r.isPhoneNumber(r.TelephoneNumber, "packed base segment"); err != nil {
-		return err
-	}
-	return nil
-}
-
-// validation of social security number
-func (r *PackedBaseSegment) ValidateSocialSecurityNumber() error {
-	if r.SocialSecurityNumber == 0 && r.DateBirth.IsZero() {
-		// social security number and date birth may omit for business account
-		if r.ECOACode == "2" || r.ECOACode == "5" {
-			return nil
-		}
-		return utils.NewErrInvalidValueOfField("social security number", "base segment")
-	}
-	return nil
-}
-
-// validation of date of birth
-func (r *PackedBaseSegment) ValidateDateBirth() error {
-	if r.SocialSecurityNumber == 0 && r.DateBirth.IsZero() {
-		// social security number and date birth may omit for business account
-		if r.ECOACode == "2" || r.ECOACode == "5" {
-			return nil
-		}
-		return utils.NewErrInvalidValueOfField("date birth", "base segment")
-	}
-	return nil
-}
-
-// validation of account status
-func (r *PackedBaseSegment) ValidateAccountStatus() error {
-	switch r.AccountStatus {
-	case AccountStatusDF, AccountStatusDA, AccountStatus11, AccountStatus61, AccountStatus62,
-		AccountStatus63, AccountStatus64, AccountStatus71, AccountStatus78, AccountStatus80,
-		AccountStatus82, AccountStatus83, AccountStatus84, AccountStatus93, AccountStatus96,
-		AccountStatus97, AccountStatus05, AccountStatus13, AccountStatus65, AccountStatus88,
-		AccountStatus89, AccountStatus94, AccountStatus95:
-		return nil
-	}
-	return utils.NewErrInvalidValueOfField("account status", "packed base segment")
-}
-
-// validation of account type
-func (r *PackedBaseSegment) ValidateAccountType() error {
-	switch r.AccountType {
-	case AccountType00, AccountType01, AccountType02, AccountType03, AccountType04, AccountType05, AccountType06,
-		AccountType07, AccountType08, AccountType0A, AccountType0C, AccountType0F, AccountType0G, AccountType10,
-		AccountType11, AccountType12, AccountType13, AccountType15, AccountType17, AccountType18, AccountType19,
-		AccountType20, AccountType25, AccountType26, AccountType29, AccountType2A, AccountType2C, AccountType37,
-		AccountType3A, AccountType43, AccountType47, AccountType48, AccountType4D, AccountType50, AccountType5A,
-		AccountType5B, AccountType65, AccountType66, AccountType67, AccountType68, AccountType69, AccountType6A,
-		AccountType6B, AccountType6D, AccountType70, AccountType71, AccountType72, AccountType73, AccountType74,
-		AccountType75, AccountType77, AccountType7A, AccountType7B, AccountType89, AccountType8A, AccountType8B,
-		AccountType90, AccountType91, AccountType92, AccountType93, AccountType95, AccountType9A, AccountType9B:
-		return nil
-	}
-	return utils.NewErrInvalidValueOfField("account type", "packed base segment")
-}
-
-// validation of special comment
-func (r *PackedBaseSegment) ValidateSpecialComment() error {
-	switch r.SpecialComment {
-	case SpecialCommentCodeBlank, SpecialCommentCodeB, SpecialCommentCodeC, SpecialCommentCodeH, SpecialCommentCodeI,
-		SpecialCommentCodeM, SpecialCommentCodeO, SpecialCommentCodeS, SpecialCommentCodeV, SpecialCommentCodeAB,
-		SpecialCommentCodeAC, SpecialCommentCodeAH, SpecialCommentCodeAI, SpecialCommentCodeAM, SpecialCommentCodeAN,
-		SpecialCommentCodeAO, SpecialCommentCodeAP, SpecialCommentCodeAS, SpecialCommentCodeAT, SpecialCommentCodeAU,
-		SpecialCommentCodeAV, SpecialCommentCodeAW, SpecialCommentCodeAX, SpecialCommentCodeAZ, SpecialCommentCodeBA,
-		SpecialCommentCodeBB, SpecialCommentCodeBC, SpecialCommentCodeBD, SpecialCommentCodeBE, SpecialCommentCodeBF,
-		SpecialCommentCodeBG, SpecialCommentCodeBH, SpecialCommentCodeBI, SpecialCommentCodeBJ, SpecialCommentCodeBK,
-		SpecialCommentCodeBL, SpecialCommentCodeBN, SpecialCommentCodeBO, SpecialCommentCodeBP, SpecialCommentCodeBS,
-		SpecialCommentCodeBT, SpecialCommentCodeCH, SpecialCommentCodeCI, SpecialCommentCodeCJ, SpecialCommentCodeCK,
-		SpecialCommentCodeCL, SpecialCommentCodeCM, SpecialCommentCodeCN, SpecialCommentCodeCO, SpecialCommentCodeCP,
-		SpecialCommentCodeCS, SpecialCommentCodeDE:
-
-		return nil
-	}
-	return utils.NewErrInvalidValueOfField("special comment", "packed base segment")
-}
+// Validation methods are inherited from baseSegmentCore
 
 func readApplicableSegments(record []byte, f Record, isVariableLength bool) (int, error) {
 	var segment Segment

--- a/pkg/lib/base_segment.go
+++ b/pkg/lib/base_segment.go
@@ -718,11 +718,11 @@ func (r *baseSegmentCore) AddApplicableSegment(s Segment) error {
 }
 
 // MarshalJSON returns JSON blob
-func (r *BaseSegment) MarshalJSON() ([]byte, error) {
+func (r *baseSegmentCore) MarshalJSON() ([]byte, error) {
 	dummy := dataRecordJson{}
 	base := baseJson{}
 
-	fromFields := reflect.ValueOf(&r.baseSegmentCore).Elem()
+	fromFields := reflect.ValueOf(r).Elem()
 	toFields := reflect.ValueOf(&base).Elem()
 	for i := 0; i < fromFields.NumField(); i++ {
 		fieldName := fromFields.Type().Field(i).Name
@@ -747,8 +747,7 @@ func (r *BaseSegment) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON parses a JSON blob
-func (r *BaseSegment) UnmarshalJSON(data []byte) error {
-
+func (r *baseSegmentCore) UnmarshalJSON(data []byte) error {
 	dummy := make(map[string]interface{})
 	if err := json.Unmarshal(data, &dummy); err != nil {
 		return fmt.Errorf("invalid json format (%s)", err.Error())
@@ -771,7 +770,7 @@ func (r *BaseSegment) UnmarshalJSON(data []byte) error {
 			}
 
 			fromFields := reflect.ValueOf(&base).Elem()
-			toFields := reflect.ValueOf(&r.baseSegmentCore).Elem()
+			toFields := reflect.ValueOf(r).Elem()
 			for i := 0; i < fromFields.NumField(); i++ {
 				fieldName := fromFields.Type().Field(i).Name
 				fromField := fromFields.FieldByName(fieldName)
@@ -791,13 +790,13 @@ func (r *BaseSegment) UnmarshalJSON(data []byte) error {
 				if parseErr != nil {
 					return parseErr
 				}
-				parseErr = unmarshalApplicableSegments(key, subBuf, r)
+				parseErr = r.unmarshalApplicableSegment(key, subBuf)
 				if parseErr != nil {
 					return parseErr
 				}
 			}
 		default:
-			err = unmarshalApplicableSegments(key, buf, r)
+			err = r.unmarshalApplicableSegment(key, buf)
 		}
 
 		if err != nil {
@@ -806,6 +805,38 @@ func (r *BaseSegment) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// unmarshalApplicableSegment is a helper for UnmarshalJSON
+func (r *baseSegmentCore) unmarshalApplicableSegment(description string, data []byte) error {
+	var segment Segment
+
+	switch description {
+	case J1SegmentName:
+		segment = NewJ1Segment()
+	case J2SegmentName:
+		segment = NewJ2Segment()
+	case K1SegmentName:
+		segment = NewK1Segment()
+	case K2SegmentName:
+		segment = NewK2Segment()
+	case K3SegmentName:
+		segment = NewK3Segment()
+	case K4SegmentName:
+		segment = NewK4Segment()
+	case L1SegmentName:
+		segment = NewL1Segment()
+	case N1SegmentName:
+		segment = NewN1Segment()
+	default:
+		return nil
+	}
+
+	err := json.Unmarshal(data, segment)
+	if err != nil {
+		return fmt.Errorf("unabled to parse %s segment (%s)", description, err.Error())
+	}
+	return r.AddApplicableSegment(segment)
 }
 
 // customized field validation functions
@@ -1152,98 +1183,8 @@ func (r *PackedBaseSegment) Length() int {
 	return r.RecordDescriptorWord
 }
 
-// GetSegments and AddApplicableSegment are inherited from baseSegmentCore
-
-// MarshalJSON returns JSON blob
-func (r *PackedBaseSegment) MarshalJSON() ([]byte, error) {
-	dummy := dataRecordJson{}
-	base := baseJson{}
-
-	fromFields := reflect.ValueOf(&r.baseSegmentCore).Elem()
-	toFields := reflect.ValueOf(&base).Elem()
-	for i := 0; i < fromFields.NumField(); i++ {
-		fieldName := fromFields.Type().Field(i).Name
-		fromField := fromFields.FieldByName(fieldName)
-		toField := toFields.FieldByName(fieldName)
-		if fromField.IsValid() && toField.CanSet() {
-			toField.Set(fromField)
-		}
-	}
-
-	dummy.Base = base
-	dummy.J1Segments = r.j1Segments
-	dummy.J2Segments = r.j2Segments
-	dummy.K1Segment = r.k1Segment
-	dummy.K2Segment = r.k2Segment
-	dummy.K3Segment = r.k3Segment
-	dummy.K4Segment = r.k4Segment
-	dummy.L1Segment = r.l1Segment
-	dummy.N1Segment = r.n1Segment
-
-	return json.Marshal(dummy)
-}
-
-// UnmarshalJSON parses a JSON blob
-func (r *PackedBaseSegment) UnmarshalJSON(data []byte) error {
-
-	dummy := make(map[string]interface{})
-	if err := json.Unmarshal(data, &dummy); err != nil {
-		return fmt.Errorf("invalid json format (%s)", err.Error())
-	}
-
-	r.j1Segments = []Segment{}
-	r.j2Segments = []Segment{}
-
-	for key, record := range dummy {
-		buf, err := json.Marshal(record)
-		if err != nil {
-			return fmt.Errorf("invalid %s segment (%s)", key, err.Error())
-		}
-
-		switch key {
-		case BaseSegmentName:
-			base := baseJson{}
-			if parseErr := json.Unmarshal(buf, &base); parseErr != nil {
-				return fmt.Errorf("unabled to parse %s segment (%s)", key, parseErr.Error())
-			}
-			fromFields := reflect.ValueOf(&base).Elem()
-			toFields := reflect.ValueOf(&r.baseSegmentCore).Elem()
-			for i := 0; i < fromFields.NumField(); i++ {
-				fieldName := fromFields.Type().Field(i).Name
-				fromField := fromFields.FieldByName(fieldName)
-				toField := toFields.FieldByName(fieldName)
-				if fromField.IsValid() && toField.CanSet() {
-					toField.Set(fromField)
-				}
-			}
-		case J1SegmentName, J2SegmentName:
-			var list []interface{}
-			if parseErr := json.Unmarshal(buf, &list); parseErr != nil {
-				return fmt.Errorf("unabled to parse %s segment (%s)", key, parseErr.Error())
-			}
-			for _, subSegment := range list {
-				subBuf, parseErr := json.Marshal(subSegment)
-				if parseErr != nil {
-					return parseErr
-				}
-				parseErr = unmarshalApplicableSegments(key, subBuf, r)
-				if parseErr != nil {
-					return parseErr
-				}
-			}
-		default:
-			err = unmarshalApplicableSegments(key, buf, r)
-		}
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// Validation methods are inherited from baseSegmentCore
+// GetSegments, AddApplicableSegment, MarshalJSON, UnmarshalJSON and Validation methods
+// are inherited from baseSegmentCore
 
 func readApplicableSegments(record []byte, f Record, isVariableLength bool) (int, error) {
 	var segment Segment
@@ -1284,33 +1225,3 @@ func readApplicableSegments(record []byte, f Record, isVariableLength bool) (int
 	return offset, nil
 }
 
-func unmarshalApplicableSegments(description string, data []byte, r Record) error {
-	var segment Segment
-
-	switch description {
-	case J1SegmentName:
-		segment = NewJ1Segment()
-	case J2SegmentName:
-		segment = NewJ2Segment()
-	case K1SegmentName:
-		segment = NewK1Segment()
-	case K2SegmentName:
-		segment = NewK2Segment()
-	case K3SegmentName:
-		segment = NewK3Segment()
-	case K4SegmentName:
-		segment = NewK4Segment()
-	case L1SegmentName:
-		segment = NewL1Segment()
-	case N1SegmentName:
-		segment = NewN1Segment()
-	default:
-		return nil
-	}
-
-	err := json.Unmarshal(data, segment)
-	if err != nil {
-		return fmt.Errorf("unabled to parse %s segment (%s)", description, err.Error())
-	}
-	return r.AddApplicableSegment(segment)
-}

--- a/pkg/lib/base_segment_test.go
+++ b/pkg/lib/base_segment_test.go
@@ -193,7 +193,7 @@ func (t *SegmentTest) TestPackedBaseSegmentWithInvalidPortfolioType(c *check.C) 
 	segment.PortfolioType = "A"
 	err = segment.Validate()
 	c.Assert(err, check.Not(check.IsNil))
-	c.Assert(err.Error(), check.DeepEquals, "portfolio type in packed base segment has an invalid value")
+	c.Assert(err.Error(), check.DeepEquals, "portfolio type in base segment has an invalid value")
 }
 
 func (t *SegmentTest) TestPackedBaseSegmentWithInvalidTermsDuration(c *check.C) {
@@ -203,7 +203,7 @@ func (t *SegmentTest) TestPackedBaseSegmentWithInvalidTermsDuration(c *check.C) 
 	segment.TermsDuration = "AAA"
 	err = segment.Validate()
 	c.Assert(err, check.Not(check.IsNil))
-	c.Assert(err.Error(), check.DeepEquals, "terms duration in packed base segment has an invalid value")
+	c.Assert(err.Error(), check.DeepEquals, "terms duration in base segment has an invalid value")
 }
 
 func (t *SegmentTest) TestPackedBaseSegmentWithInvalidPaymentHistoryProfile(c *check.C) {
@@ -213,7 +213,7 @@ func (t *SegmentTest) TestPackedBaseSegmentWithInvalidPaymentHistoryProfile(c *c
 	segment.PaymentHistoryProfile = "Z"
 	err = segment.Validate()
 	c.Assert(err, check.Not(check.IsNil))
-	c.Assert(err.Error(), check.DeepEquals, "payment history profile in packed base segment has an invalid value")
+	c.Assert(err.Error(), check.DeepEquals, "payment history profile in base segment has an invalid value")
 }
 
 func (t *SegmentTest) TestPackedBaseSegmentWithInvalidInterestTypeIndicator(c *check.C) {
@@ -223,7 +223,7 @@ func (t *SegmentTest) TestPackedBaseSegmentWithInvalidInterestTypeIndicator(c *c
 	segment.InterestTypeIndicator = "Z"
 	err = segment.Validate()
 	c.Assert(err, check.Not(check.IsNil))
-	c.Assert(err.Error(), check.DeepEquals, "interest type indicator in packed base segment has an invalid value")
+	c.Assert(err.Error(), check.DeepEquals, "interest type indicator in base segment has an invalid value")
 }
 
 func (t *SegmentTest) TestPackedBaseSegmentWithInvalidTelephoneNumber(c *check.C) {
@@ -416,7 +416,7 @@ func (t *SegmentTest) TestPackedBaseSegmentWithInvalidAccountStatus(c *check.C) 
 	segment.AccountStatus = "FF"
 	err = segment.Validate()
 	c.Assert(err, check.Not(check.IsNil))
-	c.Assert(err.Error(), check.DeepEquals, "account status in packed base segment has an invalid value")
+	c.Assert(err.Error(), check.DeepEquals, "account status in base segment has an invalid value")
 }
 
 func (t *SegmentTest) TestBaseSegmentWithInvalidAccountType(c *check.C) {
@@ -436,7 +436,7 @@ func (t *SegmentTest) TestPackedBaseSegmentWithInvalidAccountType(c *check.C) {
 	segment.AccountType = "FF"
 	err = segment.Validate()
 	c.Assert(err, check.Not(check.IsNil))
-	c.Assert(err.Error(), check.DeepEquals, "account type in packed base segment has an invalid value")
+	c.Assert(err.Error(), check.DeepEquals, "account type in base segment has an invalid value")
 }
 
 func (t *SegmentTest) TestPackedBaseSegmentWithSocialSecurityNumber(c *check.C) {
@@ -484,5 +484,5 @@ func (t *SegmentTest) TestPackedBaseSegmentWithInvalidSpecialComment(c *check.C)
 	segment.SpecialComment = "FF"
 	err = segment.Validate()
 	c.Assert(err, check.Not(check.IsNil))
-	c.Assert(err.Error(), check.DeepEquals, "special comment in packed base segment has an invalid value")
+	c.Assert(err.Error(), check.DeepEquals, "special comment in base segment has an invalid value")
 }

--- a/pkg/lib/converters.go
+++ b/pkg/lib/converters.go
@@ -301,3 +301,29 @@ func descriptorString(data reflect.Value) string {
 
 	return string(value)
 }
+
+// parseSegmentData handles common segment parsing logic
+func (c *converter) parseSegmentData(s interface{}, segmentLength int, format map[string]field, record []byte, v *validator, segmentName string, isVariableLength bool) (int, error) {
+	if len(record) < segmentLength {
+		return 0, utils.NewErrSegmentLength(segmentName)
+	}
+	fields := reflect.ValueOf(s).Elem()
+	_, err := c.parseRecordValues(fields, format, record, v, segmentName, isVariableLength)
+	if err != nil {
+		return 0, err
+	}
+	return segmentLength, nil
+}
+
+// stringSegmentData handles common segment string conversion logic
+func (c *converter) stringSegmentData(s interface{}, segmentLength int, format map[string]field) string {
+	var buf strings.Builder
+	specifications := c.toSpecifications(format)
+	fields := reflect.ValueOf(s).Elem()
+	buf.Grow(segmentLength)
+	for _, spec := range specifications {
+		value := c.toString(spec.Field, fields.FieldByName(spec.Name))
+		buf.WriteString(value)
+	}
+	return buf.String()
+}

--- a/pkg/lib/header_record.go
+++ b/pkg/lib/header_record.go
@@ -17,8 +17,10 @@ var _ Segment = (*HeaderRecord)(nil)
 var _ Record = (*PackedHeaderRecord)(nil)
 var _ Segment = (*PackedHeaderRecord)(nil)
 
-// HeaderRecord holds the header record
-type HeaderRecord struct {
+// headerRecordCore contains all shared data fields and methods for both
+// character and packed header record formats. This eliminates code duplication
+// between HeaderRecord and PackedHeaderRecord.
+type headerRecordCore struct {
 	// Contains a value equal to the length of the block of data and must be reported when using the packed format or
 	// when reporting variable length records.  This value includes the four bytes reserved for this field.
 	// Report the standard IBM variable record length conventions.
@@ -100,8 +102,15 @@ type HeaderRecord struct {
 	validator
 }
 
+// HeaderRecord holds the header record (character format)
+type HeaderRecord struct {
+	headerRecordCore
+}
+
 // PackedHeaderRecord holds the packed header record
-type PackedHeaderRecord HeaderRecord
+type PackedHeaderRecord struct {
+	headerRecordCore
+}
 
 // Name returns name of header record
 func (r *HeaderRecord) Name() string {
@@ -114,7 +123,7 @@ func (r *HeaderRecord) Parse(record []byte, isVariableLength bool) (int, error) 
 		return 0, utils.NewErrSegmentLength("header record")
 	}
 
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.headerRecordCore).Elem()
 	length, err := r.parseRecordValues(fields, headerRecordCharacterFormat, record, &r.validator, "header record", isVariableLength)
 	if err != nil {
 		return length, err
@@ -130,7 +139,7 @@ func (r *HeaderRecord) Parse(record []byte, isVariableLength bool) (int, error) 
 func (r *HeaderRecord) String() string {
 	var buf strings.Builder
 	specifications := r.toSpecifications(headerRecordCharacterFormat)
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.headerRecordCore).Elem()
 	blockSize := r.BlockDescriptorWord
 	if blockSize == 0 {
 		blockSize = r.RecordDescriptorWord
@@ -154,21 +163,21 @@ func (r *HeaderRecord) Bytes() []byte {
 
 // Validate performs some checks on the record and returns an error if not Validated
 func (r *HeaderRecord) Validate() error {
-	return r.validateRecord(r, headerRecordCharacterFormat, "header record")
+	return r.validateRecord(&r.headerRecordCore, headerRecordCharacterFormat, "header record")
 }
 
 // BlockSize returns size of block
-func (r *HeaderRecord) BlockSize() int {
+func (r *headerRecordCore) BlockSize() int {
 	return r.BlockDescriptorWord
 }
 
 // Length returns size of segment
-func (r *HeaderRecord) Length() int {
+func (r *headerRecordCore) Length() int {
 	return r.RecordDescriptorWord
 }
 
 // GetSegments returns list of applicable segments by segment name
-func (r *HeaderRecord) GetSegments(string) []Segment {
+func (r *headerRecordCore) GetSegments(string) []Segment {
 	return nil
 }
 
@@ -188,7 +197,7 @@ func (r *PackedHeaderRecord) Parse(record []byte, isVariableLength bool) (int, e
 		return 0, utils.NewErrSegmentLength("packed header record")
 	}
 
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.headerRecordCore).Elem()
 	offset := 0
 	for i := 0; i < fields.NumField(); i++ {
 		fieldName := fields.Type().Field(i).Name
@@ -243,7 +252,7 @@ func (r *PackedHeaderRecord) Parse(record []byte, isVariableLength bool) (int, e
 func (r *PackedHeaderRecord) String() string {
 	var buf strings.Builder
 	specifications := r.toSpecifications(headerRecordPackedFormat)
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.headerRecordCore).Elem()
 	blockSize := r.BlockDescriptorWord
 	if blockSize == 0 {
 		blockSize = r.RecordDescriptorWord
@@ -267,7 +276,7 @@ func (r *PackedHeaderRecord) Bytes() []byte {
 
 // Validate performs some checks on the record and returns an error if not Validated
 func (r *PackedHeaderRecord) Validate() error {
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.headerRecordCore).Elem()
 	for i := 0; i < fields.NumField(); i++ {
 		fieldName := fields.Type().Field(i).Name
 		if spec, ok := headerRecordPackedFormat[fieldName]; ok {
@@ -283,20 +292,7 @@ func (r *PackedHeaderRecord) Validate() error {
 	return nil
 }
 
-// BlockSize returns size of block
-func (r *PackedHeaderRecord) BlockSize() int {
-	return r.BlockDescriptorWord
-}
-
-// Length returns size of segment
-func (r *PackedHeaderRecord) Length() int {
-	return r.RecordDescriptorWord
-}
-
-// GetSegments returns list of applicable segments by segment name
-func (r *PackedHeaderRecord) GetSegments(string) []Segment {
-	return nil
-}
+// BlockSize, Length, and GetSegments are inherited from headerRecordCore
 
 // AddApplicableSegment will add new applicable segment into record
 func (r *PackedHeaderRecord) AddApplicableSegment(s Segment) error {

--- a/pkg/lib/j1_segment.go
+++ b/pkg/lib/j1_segment.go
@@ -5,9 +5,6 @@
 package lib
 
 import (
-	"reflect"
-	"strings"
-
 	"github.com/moov-io/metro2/pkg/utils"
 )
 
@@ -113,31 +110,12 @@ func (s *J1Segment) Name() string {
 
 // Parse takes the input record string and parses the j1 segment values
 func (s *J1Segment) Parse(record []byte, isVariableLength bool) (int, error) {
-	if len(record) < J1SegmentLength {
-		return 0, utils.NewErrSegmentLength("j1 segment")
-	}
-
-	fields := reflect.ValueOf(s).Elem()
-	length, err := s.parseRecordValues(fields, j1SegmentFormat, record, &s.validator, "j1 segment", isVariableLength)
-	if err != nil {
-		return length, err
-	}
-
-	return J1SegmentLength, nil
+	return s.parseSegmentData(s, J1SegmentLength, j1SegmentFormat, record, &s.validator, "j1 segment", isVariableLength)
 }
 
 // String writes the j1 segment struct to a 100 character string.
 func (s *J1Segment) String() string {
-	var buf strings.Builder
-	specifications := s.toSpecifications(j1SegmentFormat)
-	fields := reflect.ValueOf(s).Elem()
-	buf.Grow(J1SegmentLength)
-	for _, spec := range specifications {
-		value := s.toString(spec.Field, fields.FieldByName(spec.Name))
-		buf.WriteString(value)
-	}
-
-	return buf.String()
+	return s.stringSegmentData(s, J1SegmentLength, j1SegmentFormat)
 }
 
 // Bytes return raw byte array

--- a/pkg/lib/j2_segment.go
+++ b/pkg/lib/j2_segment.go
@@ -5,7 +5,6 @@
 package lib
 
 import (
-	"reflect"
 	"strings"
 
 	"github.com/moov-io/metro2/pkg/utils"
@@ -169,31 +168,12 @@ func (s *J2Segment) Name() string {
 
 // Parse takes the input record string and parses the j2 segment values
 func (s *J2Segment) Parse(record []byte, isVariableLength bool) (int, error) {
-	if len(record) < J2SegmentLength {
-		return 0, utils.NewErrSegmentLength("j2 segment")
-	}
-
-	fields := reflect.ValueOf(s).Elem()
-	length, err := s.parseRecordValues(fields, j2SegmentFormat, record, &s.validator, "j2 segment", isVariableLength)
-	if err != nil {
-		return length, err
-	}
-
-	return J2SegmentLength, nil
+	return s.parseSegmentData(s, J2SegmentLength, j2SegmentFormat, record, &s.validator, "j2 segment", isVariableLength)
 }
 
 // String writes the j2 segment struct to a 200 character string.
 func (s *J2Segment) String() string {
-	var buf strings.Builder
-	specifications := s.toSpecifications(j2SegmentFormat)
-	fields := reflect.ValueOf(s).Elem()
-	buf.Grow(J2SegmentLength)
-	for _, spec := range specifications {
-		value := s.toString(spec.Field, fields.FieldByName(spec.Name))
-		buf.WriteString(value)
-	}
-
-	return buf.String()
+	return s.stringSegmentData(s, J2SegmentLength, j2SegmentFormat)
 }
 
 // Bytes return raw byte array

--- a/pkg/lib/kn_segment.go
+++ b/pkg/lib/kn_segment.go
@@ -5,9 +5,6 @@
 package lib
 
 import (
-	"reflect"
-	"strings"
-
 	"github.com/moov-io/metro2/pkg/utils"
 )
 
@@ -68,31 +65,12 @@ func (s *K1Segment) Name() string {
 
 // Parse takes the input record string and parses the k1 segment values
 func (s *K1Segment) Parse(record []byte, isVariableLength bool) (int, error) {
-	if len(record) < K1SegmentLength {
-		return 0, utils.NewErrSegmentLength("k1 segment")
-	}
-
-	fields := reflect.ValueOf(s).Elem()
-	length, err := s.parseRecordValues(fields, k1SegmentFormat, record, &s.validator, "k1 segment", isVariableLength)
-	if err != nil {
-		return length, err
-	}
-
-	return K1SegmentLength, nil
+	return s.parseSegmentData(s, K1SegmentLength, k1SegmentFormat, record, &s.validator, "k1 segment", isVariableLength)
 }
 
 // String writes the k1 segment struct to a 34 character string.
 func (s *K1Segment) String() string {
-	var buf strings.Builder
-	specifications := s.toSpecifications(k1SegmentFormat)
-	fields := reflect.ValueOf(s).Elem()
-	buf.Grow(K1SegmentLength)
-	for _, spec := range specifications {
-		value := s.toString(spec.Field, fields.FieldByName(spec.Name))
-		buf.WriteString(value)
-	}
-
-	return buf.String()
+	return s.stringSegmentData(s, K1SegmentLength, k1SegmentFormat)
 }
 
 // Bytes return raw byte array
@@ -149,31 +127,12 @@ func (s *K2Segment) Name() string {
 
 // Parse takes the input record string and parses the k2 segment values
 func (s *K2Segment) Parse(record []byte, isVariableLength bool) (int, error) {
-	if len(record) < K2SegmentLength {
-		return 0, utils.NewErrSegmentLength("k2 segment")
-	}
-
-	fields := reflect.ValueOf(s).Elem()
-	length, err := s.parseRecordValues(fields, k2SegmentFormat, record, &s.validator, "k2 segment", isVariableLength)
-	if err != nil {
-		return length, err
-	}
-
-	return K2SegmentLength, nil
+	return s.parseSegmentData(s, K2SegmentLength, k2SegmentFormat, record, &s.validator, "k2 segment", isVariableLength)
 }
 
 // String writes the k2 segment struct to a 34 character string.
 func (s *K2Segment) String() string {
-	var buf strings.Builder
-	specifications := s.toSpecifications(k2SegmentFormat)
-	fields := reflect.ValueOf(s).Elem()
-	buf.Grow(K2SegmentLength)
-	for _, spec := range specifications {
-		value := s.toString(spec.Field, fields.FieldByName(spec.Name))
-		buf.WriteString(value)
-	}
-
-	return buf.String()
+	return s.stringSegmentData(s, K2SegmentLength, k2SegmentFormat)
 }
 
 // Bytes return raw byte array
@@ -242,17 +201,7 @@ func (s *K3Segment) Name() string {
 
 // Parse takes the input record string and parses the k3 segment values
 func (s *K3Segment) Parse(record []byte, isVariableLength bool) (int, error) {
-	if len(record) < K3SegmentLength {
-		return 0, utils.NewErrSegmentLength("k3 segment")
-	}
-
-	fields := reflect.ValueOf(s).Elem()
-	length, err := s.parseRecordValues(fields, k3SegmentFormat, record, &s.validator, "k3 segment", isVariableLength)
-	if err != nil {
-		return length, err
-	}
-
-	return K3SegmentLength, nil
+	return s.parseSegmentData(s, K3SegmentLength, k3SegmentFormat, record, &s.validator, "k3 segment", isVariableLength)
 }
 
 // Bytes return raw byte array
@@ -262,16 +211,7 @@ func (s *K3Segment) Bytes() []byte {
 
 // String writes the k3 segment struct to a 40 character string.
 func (s *K3Segment) String() string {
-	var buf strings.Builder
-	specifications := s.toSpecifications(k3SegmentFormat)
-	fields := reflect.ValueOf(s).Elem()
-	buf.Grow(K3SegmentLength)
-	for _, spec := range specifications {
-		value := s.toString(spec.Field, fields.FieldByName(spec.Name))
-		buf.WriteString(value)
-	}
-
-	return buf.String()
+	return s.stringSegmentData(s, K3SegmentLength, k3SegmentFormat)
 }
 
 // Validate performs some checks on the record and returns an error if not Validated
@@ -336,17 +276,7 @@ func (s *K4Segment) Name() string {
 
 // Parse takes the input record string and parses the k4 segment values
 func (s *K4Segment) Parse(record []byte, isVariableLength bool) (int, error) {
-	if len(record) < K4SegmentLength {
-		return 0, utils.NewErrSegmentLength("k4 segment")
-	}
-
-	fields := reflect.ValueOf(s).Elem()
-	length, err := s.parseRecordValues(fields, k4SegmentFormat, record, &s.validator, "k4 segment", isVariableLength)
-	if err != nil {
-		return length, err
-	}
-
-	return K4SegmentLength, nil
+	return s.parseSegmentData(s, K4SegmentLength, k4SegmentFormat, record, &s.validator, "k4 segment", isVariableLength)
 }
 
 // Bytes return raw byte array
@@ -356,16 +286,7 @@ func (s *K4Segment) Bytes() []byte {
 
 // String writes the k4 segment struct to a 30 character string.
 func (s *K4Segment) String() string {
-	var buf strings.Builder
-	specifications := s.toSpecifications(k4SegmentFormat)
-	fields := reflect.ValueOf(s).Elem()
-	buf.Grow(K4SegmentLength)
-	for _, spec := range specifications {
-		value := s.toString(spec.Field, fields.FieldByName(spec.Name))
-		buf.WriteString(value)
-	}
-
-	return buf.String()
+	return s.stringSegmentData(s, K4SegmentLength, k4SegmentFormat)
 }
 
 // Validate performs some checks on the record and returns an error if not Validated

--- a/pkg/lib/l1_segment.go
+++ b/pkg/lib/l1_segment.go
@@ -5,9 +5,6 @@
 package lib
 
 import (
-	"reflect"
-	"strings"
-
 	"github.com/moov-io/metro2/pkg/utils"
 )
 
@@ -46,31 +43,12 @@ func (s *L1Segment) Name() string {
 
 // Parse takes the input record string and parses the l1 segment values
 func (s *L1Segment) Parse(record []byte, isVariableLength bool) (int, error) {
-	if len(record) < L1SegmentLength {
-		return 0, utils.NewErrSegmentLength("l1 segment")
-	}
-
-	fields := reflect.ValueOf(s).Elem()
-	length, err := s.parseRecordValues(fields, l1SegmentFormat, record, &s.validator, "l1 segment", isVariableLength)
-	if err != nil {
-		return length, err
-	}
-
-	return L1SegmentLength, nil
+	return s.parseSegmentData(s, L1SegmentLength, l1SegmentFormat, record, &s.validator, "l1 segment", isVariableLength)
 }
 
 // String writes the l1 segment struct to a 54 character string.
 func (s *L1Segment) String() string {
-	var buf strings.Builder
-	specifications := s.toSpecifications(l1SegmentFormat)
-	fields := reflect.ValueOf(s).Elem()
-	buf.Grow(L1SegmentLength)
-	for _, spec := range specifications {
-		value := s.toString(spec.Field, fields.FieldByName(spec.Name))
-		buf.WriteString(value)
-	}
-
-	return buf.String()
+	return s.stringSegmentData(s, L1SegmentLength, l1SegmentFormat)
 }
 
 // Bytes return raw byte array

--- a/pkg/lib/n1_segment.go
+++ b/pkg/lib/n1_segment.go
@@ -1,12 +1,5 @@
 package lib
 
-import (
-	"reflect"
-	"strings"
-
-	"github.com/moov-io/metro2/pkg/utils"
-)
-
 var _ Segment = (*N1Segment)(nil)
 
 // N1Segment holds the n1 segment
@@ -49,31 +42,12 @@ func (s *N1Segment) Name() string {
 
 // Parse takes the input record string and parses the n1 segment values
 func (s *N1Segment) Parse(record []byte, isVariableLength bool) (int, error) {
-	if len(record) < N1SegmentLength {
-		return 0, utils.NewErrSegmentLength("n1 segment")
-	}
-
-	fields := reflect.ValueOf(s).Elem()
-	length, err := s.parseRecordValues(fields, n1SegmentFormat, record, &s.validator, "n1 segment", isVariableLength)
-	if err != nil {
-		return length, err
-	}
-
-	return N1SegmentLength, nil
+	return s.parseSegmentData(s, N1SegmentLength, n1SegmentFormat, record, &s.validator, "n1 segment", isVariableLength)
 }
 
 // String writes the n1 segment struct to a 146 character string.
 func (s *N1Segment) String() string {
-	var buf strings.Builder
-	specifications := s.toSpecifications(n1SegmentFormat)
-	fields := reflect.ValueOf(s).Elem()
-	buf.Grow(N1SegmentLength)
-	for _, spec := range specifications {
-		value := s.toString(spec.Field, fields.FieldByName(spec.Name))
-		buf.WriteString(value)
-	}
-
-	return buf.String()
+	return s.stringSegmentData(s, N1SegmentLength, n1SegmentFormat)
 }
 
 // Bytes return raw byte array

--- a/pkg/lib/record.go
+++ b/pkg/lib/record.go
@@ -44,28 +44,36 @@ const (
 // NewHeaderRecord returns a new header record
 func NewHeaderRecord() Record {
 	return &HeaderRecord{
-		RecordIdentifier: HeaderIdentifier,
+		headerRecordCore: headerRecordCore{
+			RecordIdentifier: HeaderIdentifier,
+		},
 	}
 }
 
 // NewPackedHeaderRecord returns a new packed header record
 func NewPackedHeaderRecord() Record {
 	return &PackedHeaderRecord{
-		RecordIdentifier: HeaderIdentifier,
+		headerRecordCore: headerRecordCore{
+			RecordIdentifier: HeaderIdentifier,
+		},
 	}
 }
 
 // NewTrailerRecord returns a new trailer record
 func NewTrailerRecord() Record {
 	return &TrailerRecord{
-		RecordIdentifier: TrailerIdentifier,
+		trailerRecordCore: trailerRecordCore{
+			RecordIdentifier: TrailerIdentifier,
+		},
 	}
 }
 
 // NewPackedTrailerRecord returns a new packed trailer record
 func NewPackedTrailerRecord() Record {
 	return &PackedTrailerRecord{
-		RecordIdentifier: TrailerIdentifier,
+		trailerRecordCore: trailerRecordCore{
+			RecordIdentifier: TrailerIdentifier,
+		},
 	}
 }
 

--- a/pkg/lib/trailer_record.go
+++ b/pkg/lib/trailer_record.go
@@ -17,9 +17,10 @@ var _ Segment = (*TrailerRecord)(nil)
 var _ Record = (*PackedTrailerRecord)(nil)
 var _ Segment = (*PackedTrailerRecord)(nil)
 
-// TrailerRecord holds the trailer record
-type TrailerRecord struct {
-
+// trailerRecordCore contains all shared data fields and methods for both
+// character and packed trailer record formats. This eliminates code duplication
+// between TrailerRecord and PackedTrailerRecord.
+type trailerRecordCore struct {
 	// Contains a value equal to the length of the physical record. This value includes the four bytes reserved for this field.
 	// If fixed-length records are being reported, the Trailer Record should be the same length as all the data records.
 	// The Trailer Record should be padded with blanks to fill the needed number of positions.
@@ -164,7 +165,18 @@ type TrailerRecord struct {
 	validator
 }
 
-type TrailerInformation TrailerRecord
+// TrailerRecord holds the trailer record (character format)
+type TrailerRecord struct {
+	trailerRecordCore
+}
+
+// PackedTrailerRecord holds the packed trailer record
+type PackedTrailerRecord struct {
+	trailerRecordCore
+}
+
+// TrailerInformation is an alias for trailerRecordCore for backward compatibility
+type TrailerInformation trailerRecordCore
 
 // Name returns name of trailer record
 func (r *TrailerRecord) Name() string {
@@ -177,7 +189,7 @@ func (r *TrailerRecord) Parse(record []byte, isVariableLength bool) (int, error)
 		return 0, utils.NewErrSegmentLength("trailer record")
 	}
 
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.trailerRecordCore).Elem()
 	length, err := r.parseRecordValues(fields, trailerRecordCharacterFormat, record, &r.validator, "trailer record", isVariableLength)
 	if err != nil {
 		return length, err
@@ -190,7 +202,7 @@ func (r *TrailerRecord) Parse(record []byte, isVariableLength bool) (int, error)
 func (r *TrailerRecord) String() string {
 	var buf strings.Builder
 	specifications := r.toSpecifications(trailerRecordCharacterFormat)
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.trailerRecordCore).Elem()
 	blockSize := r.RecordDescriptorWord
 	if blockSize == 0 {
 		blockSize = r.RecordDescriptorWord
@@ -214,21 +226,21 @@ func (r *TrailerRecord) Bytes() []byte {
 
 // Validate performs some checks on the record and returns an error if not Validated
 func (r *TrailerRecord) Validate() error {
-	return r.validateRecord(r, trailerRecordCharacterFormat, "trailer record")
+	return r.validateRecord(&r.trailerRecordCore, trailerRecordCharacterFormat, "trailer record")
 }
 
 // BlockSize returns size of block
-func (r *TrailerRecord) BlockSize() int {
+func (r *trailerRecordCore) BlockSize() int {
 	return r.RecordDescriptorWord
 }
 
 // Length returns size of record
-func (r *TrailerRecord) Length() int {
+func (r *trailerRecordCore) Length() int {
 	return r.RecordDescriptorWord
 }
 
 // GetSegments returns list of applicable segments by segment name
-func (r *TrailerRecord) GetSegments(string) []Segment {
+func (r *trailerRecordCore) GetSegments(string) []Segment {
 	return nil
 }
 
@@ -236,9 +248,6 @@ func (r *TrailerRecord) GetSegments(string) []Segment {
 func (r *TrailerRecord) AddApplicableSegment(s Segment) error {
 	return utils.NewErrApplicableSegment("trailer record", s.Name())
 }
-
-// PackedTrailerRecord holds the packed trailer record
-type PackedTrailerRecord TrailerRecord
 
 // Name returns name of packed trailer record
 func (r *PackedTrailerRecord) Name() string {
@@ -251,7 +260,7 @@ func (r *PackedTrailerRecord) Parse(record []byte, isVariableLength bool) (int, 
 		return 0, utils.NewErrSegmentLength("packed trailer record")
 	}
 
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.trailerRecordCore).Elem()
 	offset := 0
 	for i := 0; i < fields.NumField(); i++ {
 		fieldName := fields.Type().Field(i).Name
@@ -290,7 +299,7 @@ func (r *PackedTrailerRecord) Parse(record []byte, isVariableLength bool) (int, 
 func (r *PackedTrailerRecord) String() string {
 	var buf strings.Builder
 	specifications := r.toSpecifications(trailerRecordPackedFormat)
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.trailerRecordCore).Elem()
 	blockSize := r.RecordDescriptorWord
 	if blockSize == 0 {
 		blockSize = r.RecordDescriptorWord
@@ -314,7 +323,7 @@ func (r *PackedTrailerRecord) Bytes() []byte {
 
 // Validate performs some checks on the record and returns an error if not Validated
 func (r *PackedTrailerRecord) Validate() error {
-	fields := reflect.ValueOf(r).Elem()
+	fields := reflect.ValueOf(&r.trailerRecordCore).Elem()
 	for i := 0; i < fields.NumField(); i++ {
 		fieldName := fields.Type().Field(i).Name
 		if spec, ok := trailerRecordPackedFormat[fieldName]; ok {
@@ -330,22 +339,9 @@ func (r *PackedTrailerRecord) Validate() error {
 	return nil
 }
 
-// BlockSize returns size of block
-func (r *PackedTrailerRecord) BlockSize() int {
-	return r.RecordDescriptorWord
-}
-
-// Length returns size of record
-func (r *PackedTrailerRecord) Length() int {
-	return r.RecordDescriptorWord
-}
-
-// GetSegments returns list of applicable segments by segment name
-func (r *PackedTrailerRecord) GetSegments(string) []Segment {
-	return nil
-}
+// BlockSize, Length, and GetSegments are inherited from trailerRecordCore
 
 // AddApplicableSegment will add new applicable segment into record
 func (r *PackedTrailerRecord) AddApplicableSegment(s Segment) error {
-	return utils.NewErrApplicableSegment("packed header record", s.Name())
+	return utils.NewErrApplicableSegment("packed trailer record", s.Name())
 }


### PR DESCRIPTION
Refactor record types to use struct embedding pattern instead of type aliases, eliminating code duplication across BaseSegment, HeaderRecord, and TrailerRecord.