### PR TITLE
fix: cap record padding so huge descriptor words cannot OOM

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,13 +11,15 @@ jobs:
   fuzz:
     name: Fuzz
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
         command:
-          - "go test ./test/fuzz/... -fuzz FuzzReader -fuzztime 10m"
-          - "go test ./test/fuzz/... -fuzz FuzzJSON -fuzztime 10m"
+          # -timeout must exceed -fuzztime; the default 10m test timeout
+          # expires at the same time as fuzztime and fails the job.
+          - "go test ./test/fuzz/... -run=^$ -fuzz=^FuzzReader$ -fuzztime 10m -timeout 20m"
+          - "go test ./test/fuzz/... -run=^$ -fuzz=^FuzzJSON$ -fuzztime 10m -timeout 20m"
 
     steps:
     - name: Set up Go 1.x

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -20,6 +20,31 @@ import (
 	"github.com/moov-io/metro2/pkg/utils"
 )
 
+func TestFile_StringHugeRecordDescriptorWord(t *testing.T) {
+	// FuzzReader hung/OOM'd while minimizing JSON with recordDescriptorWord=5175555555.
+	const input = `{
+		"header": {
+			"recordDescriptorWord": 5175555555,
+			"recordIdentifier": "HEADER"
+		},
+		"trailer": {
+			"recordDescriptorWord": 426,
+			"recordIdentifier": "TRAILER"
+		}
+	}`
+
+	f, err := NewFileFromReader(strings.NewReader(input))
+	if err != nil {
+		// Parse failure is acceptable; the regression is that we must not hang or OOM.
+		return
+	}
+	out := f.String(false)
+	if len(out) > 1<<20 {
+		t.Fatalf("String() allocated %d bytes from huge descriptor word", len(out))
+	}
+	_ = f.Bytes()
+}
+
 func TestFile__Crashers(t *testing.T) {
 	paths := readCrasherInputFilePaths(t)
 	for i := range paths {

--- a/pkg/lib/base_segment.go
+++ b/pkg/lib/base_segment.go
@@ -572,8 +572,10 @@ func (r *BaseSegment) String() string {
 	var buf strings.Builder
 	specifications := r.toSpecifications(baseSegmentCharacterFormat)
 	fields := reflect.ValueOf(r).Elem()
-	blockSize := r.RecordDescriptorWord
-	buf.Grow(blockSize)
+	blockSize := clampedBlockSize(r.RecordDescriptorWord)
+	if blockSize > 0 {
+		buf.Grow(blockSize)
+	}
 	for _, spec := range specifications {
 		value := r.toString(spec.Field, fields.FieldByName(spec.Name))
 		buf.WriteString(value)
@@ -1055,7 +1057,10 @@ func (r *PackedBaseSegment) String() string {
 	if r.BlockDescriptorWord > 0 {
 		blockSize += 4
 	}
-	buf.Grow(blockSize)
+	blockSize = clampedBlockSize(blockSize)
+	if blockSize > 0 {
+		buf.Grow(blockSize)
+	}
 	for _, spec := range specifications {
 		value := r.toString(spec.Field, fields.FieldByName(spec.Name))
 		buf.WriteString(value)

--- a/pkg/lib/header_record.go
+++ b/pkg/lib/header_record.go
@@ -135,7 +135,10 @@ func (r *HeaderRecord) String() string {
 	if blockSize == 0 {
 		blockSize = r.RecordDescriptorWord
 	}
-	buf.Grow(blockSize)
+	blockSize = clampedBlockSize(blockSize)
+	if blockSize > 0 {
+		buf.Grow(blockSize)
+	}
 	for _, spec := range specifications {
 		value := r.toString(spec.Field, fields.FieldByName(spec.Name))
 		buf.WriteString(value)
@@ -248,7 +251,10 @@ func (r *PackedHeaderRecord) String() string {
 	if blockSize == 0 {
 		blockSize = r.RecordDescriptorWord
 	}
-	buf.Grow(blockSize)
+	blockSize = clampedBlockSize(blockSize)
+	if blockSize > 0 {
+		buf.Grow(blockSize)
+	}
 	for _, spec := range specifications {
 		value := r.toString(spec.Field, fields.FieldByName(spec.Name))
 		buf.WriteString(value)

--- a/pkg/lib/record.go
+++ b/pkg/lib/record.go
@@ -23,6 +23,13 @@ const (
 	// PackedSegmentLength indicates length of packed segment
 	PackedRecordLength = 366
 
+	// maxRecordPad is the largest descriptor word String() will honor when
+	// padding a record. Character-format RDW/BDW fields are 4 numeric digits
+	// (9999); packed-format fields are a 2-byte unsigned integer (65535).
+	// Values outside 1..maxRecordPad are ignored so serialization cannot
+	// allocate gigabytes or panic on malformed JSON.
+	maxRecordPad = 65535
+
 	// HeaderRecordName indicates name of header record
 	HeaderRecordName = "header"
 	// BaseSegmentName indicates name of base segment
@@ -40,6 +47,15 @@ const (
 	// HeaderIdentifier indicates record identifier of header record
 	HeaderIdentifier = "HEADER"
 )
+
+// clampedBlockSize returns a safe padding size for record serialization.
+// Non-positive and oversized descriptor words produce no extra padding.
+func clampedBlockSize(requested int) int {
+	if requested <= 0 || requested > maxRecordPad {
+		return 0
+	}
+	return requested
+}
 
 // NewHeaderRecord returns a new header record
 func NewHeaderRecord() Record {

--- a/pkg/lib/record_test.go
+++ b/pkg/lib/record_test.go
@@ -1,0 +1,87 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package lib
+
+import "testing"
+
+func TestClampedBlockSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		requested int
+		want      int
+	}{
+		{name: "zero", requested: 0, want: 0},
+		{name: "negative", requested: -1, want: 0},
+		{name: "standard unpacked", requested: UnpackedRecordLength, want: UnpackedRecordLength},
+		{name: "standard packed", requested: PackedRecordLength, want: PackedRecordLength},
+		{name: "max allowed", requested: maxRecordPad, want: maxRecordPad},
+		{name: "just over max", requested: maxRecordPad + 1, want: 0},
+		{name: "fuzz rdw", requested: 5175555555, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := clampedBlockSize(tt.requested); got != tt.want {
+				t.Fatalf("clampedBlockSize(%d) = %d, want %d", tt.requested, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeaderRecordStringHugeDescriptorWord(t *testing.T) {
+	t.Parallel()
+
+	// Reproduces FuzzReader crash 1b557a3a811c2d1b: JSON with a multi-GB
+	// recordDescriptorWord used to make String() allocate until the process died.
+	record := &HeaderRecord{
+		RecordDescriptorWord: 5175555555,
+		RecordIdentifier:     HeaderIdentifier,
+	}
+	out := record.String()
+	if len(out) > maxRecordPad {
+		t.Fatalf("String() allocated %d bytes from huge descriptor word", len(out))
+	}
+	if len(out) == 0 {
+		t.Fatal("String() returned empty output")
+	}
+}
+
+func TestTrailerRecordStringHugeDescriptorWord(t *testing.T) {
+	t.Parallel()
+
+	record := &TrailerRecord{
+		RecordDescriptorWord: 5175555555,
+		RecordIdentifier:     TrailerIdentifier,
+	}
+	out := record.String()
+	if len(out) > maxRecordPad {
+		t.Fatalf("String() allocated %d bytes from huge descriptor word", len(out))
+	}
+}
+
+func TestBaseSegmentStringHugeDescriptorWord(t *testing.T) {
+	t.Parallel()
+
+	record := &BaseSegment{
+		RecordDescriptorWord: 5175555555,
+	}
+	out := record.String()
+	if len(out) > maxRecordPad {
+		t.Fatalf("String() allocated %d bytes from huge descriptor word", len(out))
+	}
+}
+
+func TestHeaderRecordStringNegativeDescriptorWord(t *testing.T) {
+	t.Parallel()
+
+	record := &HeaderRecord{
+		RecordDescriptorWord: -1,
+		RecordIdentifier:     HeaderIdentifier,
+	}
+	// Must not panic on strings.Builder.Grow / strings.Repeat
+	_ = record.String()
+}

--- a/pkg/lib/trailer_record.go
+++ b/pkg/lib/trailer_record.go
@@ -191,11 +191,10 @@ func (r *TrailerRecord) String() string {
 	var buf strings.Builder
 	specifications := r.toSpecifications(trailerRecordCharacterFormat)
 	fields := reflect.ValueOf(r).Elem()
-	blockSize := r.RecordDescriptorWord
-	if blockSize == 0 {
-		blockSize = r.RecordDescriptorWord
+	blockSize := clampedBlockSize(r.RecordDescriptorWord)
+	if blockSize > 0 {
+		buf.Grow(blockSize)
 	}
-	buf.Grow(blockSize)
 	for _, spec := range specifications {
 		value := r.toString(spec.Field, fields.FieldByName(spec.Name))
 		buf.WriteString(value)
@@ -291,11 +290,10 @@ func (r *PackedTrailerRecord) String() string {
 	var buf strings.Builder
 	specifications := r.toSpecifications(trailerRecordPackedFormat)
 	fields := reflect.ValueOf(r).Elem()
-	blockSize := r.RecordDescriptorWord
-	if blockSize == 0 {
-		blockSize = r.RecordDescriptorWord
+	blockSize := clampedBlockSize(r.RecordDescriptorWord)
+	if blockSize > 0 {
+		buf.Grow(blockSize)
 	}
-	buf.Grow(blockSize)
 	for _, spec := range specifications {
 		value := r.toString(spec.Field, fields.FieldByName(spec.Name))
 		buf.WriteString(value)

--- a/test/fuzz/testdata/fuzz/FuzzJSON/1b557a3a811c2d1b
+++ b/test/fuzz/testdata/fuzz/FuzzJSON/1b557a3a811c2d1b
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("{\n  \"header\": {\n    \"recordDescriptorWord\": 5175555555,\n    \"recordIdentifier\": \"HEADER\"\n  },\n  \"trailer\": {\n    \"recordDescriptorWord\": 426,\n    \"recordIdentifier\": \"TRAILER\"\n  }\n}")

--- a/test/fuzz/testdata/fuzz/FuzzReader/1b557a3a811c2d1b
+++ b/test/fuzz/testdata/fuzz/FuzzReader/1b557a3a811c2d1b
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("{\n  \"header\": {\n    \"recordDescriptorWord\": 5175555555,\n    \"recordIdentifier\": \"HEADER\"\n  },\n  \"trailer\": {\n    \"recordDescriptorWord\": 426,\n    \"recordIdentifier\": \"TRAILER\"\n  }\n}")


### PR DESCRIPTION
## Problem

[FuzzReader](https://github.com/moov-io/metro2/actions/runs/31857184357/job/94944083509) failed with:

```
fuzzing process hung or terminated unexpectedly while minimizing: EOF
Failing input written to testdata/fuzz/FuzzReader/1b557a3a811c2d1b
```

The minimized input is JSON with `recordDescriptorWord: 5175555555`. After unmarshal, `File.String()` / `Record.String()` padded the record with `strings.Repeat(" ", 5_175_555_555)`, which OOMs the fuzz worker.

## Fix

- Clamp RDW/BDW padding to 65535 (the packed-format 2-byte max; character format is a 4-digit field).
- Ignore non-positive descriptor words so `strings.Builder.Grow` / `strings.Repeat` cannot panic.
- Add the failing corpus for `FuzzReader` and `FuzzJSON`.
- Raise the fuzz job `-timeout` above `-fuzztime` so a full 10m run cannot fail with the default 10m test timeout.

## Test plan

- [x] `go test ./pkg/lib ./pkg/file ./test/fuzz -count=1`
- [x] `go test ./test/fuzz -run=FuzzReader/1b557a3a811c2d1b`
- [x] `go test ./test/fuzz -run=FuzzJSON/1b557a3a811c2d1b`
- [x] `go test ./... -count=1`