### PR TITLE
fix(utils): marshal zero-value date fields as empty JSON string

### DIFF
--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -9,16 +9,29 @@ import (
 
 type Time time.Time
 
-// UnmarshalJSON Parses the json string in the custom format
+// UnmarshalJSON Parses the json string in the custom format. An empty string
+// (as written by MarshalJSON for a not-available date field) round trips back
+// into the zero value rather than an error.
 func (ct *Time) UnmarshalJSON(b []byte) (err error) {
 	s := strings.Trim(string(b), `"`)
+	if s == "" {
+		*ct = Time{}
+		return nil
+	}
 	nt, err := parseDate(s)
 	*ct = Time(nt)
 	return
 }
 
-// MarshalJSON writes a quoted string in the custom format
+// MarshalJSON writes a quoted string in the custom format. Per the CDIA
+// Metro2 spec, a numeric date field that is not available is zero-filled; a
+// zero-filled date parses to the zero value of time.Time, so it's written out
+// as an empty string instead of Go's zero time ("0001-01-01T00:00:00Z").
+// See: https://github.com/moov-io/metro2/issues/196
 func (ct Time) MarshalJSON() ([]byte, error) {
+	if ct.IsZero() {
+		return []byte(`""`), nil
+	}
 	return []byte(ct.String()), nil
 }
 

--- a/pkg/utils/time_test.go
+++ b/pkg/utils/time_test.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTime_MarshalJSON_Zero verifies that a zero-value Time (representing a
+// not-available/zero-filled date field per the CDIA Metro2 spec) marshals to
+// an empty JSON string rather than Go's zero time.Time value ("0001-01-01T00:00:00Z").
+//
+// See: https://github.com/moov-io/metro2/issues/196
+func TestTime_MarshalJSON_Zero(t *testing.T) {
+	var zero Time
+
+	out, err := json.Marshal(zero)
+	require.NoError(t, err)
+	require.Equal(t, `""`, string(out))
+}
+
+// TestTime_MarshalJSON_NonZero verifies that a populated Time still marshals
+// using the existing RFC3339 format, unaffected by the zero-value fix.
+func TestTime_MarshalJSON_NonZero(t *testing.T) {
+	tm := Time(time.Date(2020, time.January, 2, 15, 4, 5, 0, time.UTC))
+
+	out, err := json.Marshal(tm)
+	require.NoError(t, err)
+	require.Equal(t, `"2020-01-02T15:04:05Z"`, string(out))
+}
+
+// TestTime_UnmarshalJSON_EmptyString verifies that an empty JSON string round
+// trips back into a zero-value Time without erroring, so that Marshal/Unmarshal
+// remain symmetric for not-available date fields.
+func TestTime_UnmarshalJSON_EmptyString(t *testing.T) {
+	var tm Time
+	err := json.Unmarshal([]byte(`""`), &tm)
+	require.NoError(t, err)
+	require.True(t, tm.IsZero())
+}


### PR DESCRIPTION
Fixes #196.

### Description

Per the CDIA Metro2 Credit Reporting Resource Guide, a numeric date field that is not available should be zero-filled in the raw file. When converting such a record to JSON, `utils.Time.MarshalJSON` formatted the resulting zero-value `time.Time` as `"0001-01-01T00:00:00Z"` instead of a blank value, because it called `String()` unconditionally without checking `IsZero()`.

This mirrors the fixed-width `toString()` converter in `pkg/lib/converters.go`, which already special-cases `IsZero()` and zero-fills the field instead of formatting the Go zero time - `MarshalJSON` just hadn't been updated to match.

**Fix:**
- `Time.MarshalJSON` now returns `""` when the value `IsZero()`, otherwise the existing RFC3339 format is unchanged.
- `Time.UnmarshalJSON` now accepts an empty string back into the zero value (previously it errored via `parseDate("")`), so `Marshal`/`Unmarshal` remain symmetric for not-available date fields instead of round-tripping into an error.

This only touches formatting of already-zero values; non-zero dates are unaffected (covered by `TestTime_MarshalJSON_NonZero`).

Out of scope (per discussion on #196): the maintainer noted that *required* date fields (e.g. Header Record Field 8 "Activity Date") arguably should fail validation if left zero. That's a `Validate()`-time concern, separate from how an already-accepted zero value gets formatted, so I left it alone here.

### Testing

Added `pkg/utils/time_test.go` with RED/GREEN coverage:
- `TestTime_MarshalJSON_Zero` - reproduces the bug (was `"0001-01-01T00:00:00Z"`, now `""`).
- `TestTime_MarshalJSON_NonZero` - guards the unaffected non-zero formatting path.
- `TestTime_UnmarshalJSON_EmptyString` - round-trip: empty string back to zero value without error.

```
$ go test ./pkg/utils/... -run TestTime -v
--- PASS: TestTime_MarshalJSON_Zero (0.00s)
--- PASS: TestTime_MarshalJSON_NonZero (0.00s)
--- PASS: TestTime_UnmarshalJSON_EmptyString (0.00s)
```

Full suite (`go test ./...`) passes with no regressions.

<hr>

This PR has:
- [x] been tested to ensure ingestion and conversion works.
- [x] added comments explaining the "why" and the intent of the code.
- [x] no need for new documentation (bugfix in existing JSON conversion behavior).