### PR TITLE
chore(docs): bump Gemfile.lock gems for Dependabot alerts

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -27,3 +27,13 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.2.0", :platforms => [:mingw, :x64_mingw, :mswin]
 
+# Patched transitive gems for Dependabot alerts on Gemfile.lock.
+# Stay on the github-pages 7.2 Active Support line instead of 8.x.
+gem "activesupport", ">= 7.2.3.1", "< 8"
+gem "addressable", ">= 2.9.0"
+gem "concurrent-ruby", ">= 1.3.7"
+gem "faraday", ">= 2.14.3"
+gem "nokogiri", ">= 1.19.4"
+gem "rexml", ">= 3.4.2"
+gem "uri", ">= 0.13.3"
+

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,21 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.0)
+    activesupport (7.2.3.2)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
-    base64 (0.2.0)
-    bigdecimal (3.1.8)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
     bulma-clean-theme (0.14.0)
       jekyll (>= 3.9, < 5.0)
       jekyll-feed (~> 0.15)
@@ -29,12 +31,12 @@ GEM
     coffee-script-source (1.12.2)
     colorator (1.1.0)
     commonmarker (0.23.10)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.8)
+    connection_pool (3.0.2)
     csv (3.3.0)
     dnsruby (1.72.2)
       simpleidn (~> 0.2.1)
-    drb (2.2.1)
+    drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -42,11 +44,13 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.9.1)
-    faraday (2.10.1)
-      faraday-net_http (>= 2.0, < 3.2)
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
       logger
-    faraday-net_http (3.1.1)
-      net-http
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
+    ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
@@ -108,7 +112,7 @@ GEM
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
-    i18n (1.14.6)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     jekyll (3.10.0)
       addressable (~> 2.4)
@@ -220,6 +224,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
+    json (2.21.2)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -228,30 +233,34 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.0)
+    logger (1.7.0)
     mercenary (0.3.6)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.22.2)
-    nokogiri (1.18.3-arm64-darwin)
+    minitest (5.27.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.3-x86_64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.5)
+    public_suffix (5.1.1)
     racc (1.8.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
+    rexml (3.4.4)
     rouge (3.30.0)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
@@ -263,7 +272,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    securerandom (0.3.1)
+    securerandom (0.4.1)
     simpleidn (0.2.3)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -272,21 +281,29 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    uri (0.13.0)
+    uri (1.1.1)
     webrick (1.9.1)
 
 PLATFORMS
+  aarch64-linux
   universal-darwin-20
   universal-darwin-22
   universal-darwin-23
   x86_64-linux
 
 DEPENDENCIES
+  activesupport (>= 7.2.3.1, < 8)
+  addressable (>= 2.9.0)
   bulma-clean-theme
+  concurrent-ruby (>= 1.3.7)
+  faraday (>= 2.14.3)
   github-pages
   jekyll-feed (~> 0.12)
+  nokogiri (>= 1.19.4)
+  rexml (>= 3.4.2)
   tzinfo (~> 2.0)
   tzinfo-data
+  uri (>= 0.13.3)
   wdm (~> 0.2.0)
 
 BUNDLED WITH


### PR DESCRIPTION
## Problem

[Dependabot](https://github.com/moov-io/metro2/security/dependabot) has a stack of open alerts, all in `docs/Gemfile.lock` (the Jekyll / GitHub Pages site). There are no open Go module alerts.

## Updates

| Gem | From | To | Covers |
| --- | --- | --- | --- |
| nokogiri | 1.18.3 | 1.19.4 | #49–#51, #56, #61–#62, #64–#71 |
| activesupport | 7.2.0 | 7.2.3.2 | #57–#59 |
| addressable | 2.8.7 | 2.9.0 | #60 |
| concurrent-ruby | 1.3.4 | 1.3.8 | #73–#75 |
| faraday | 2.10.1 | 2.14.3 | #55, #63, #76 |
| rexml | 3.3.9 | 3.4.4 | #52 |
| uri | 0.13.0 | 1.1.1 | #48, #53 |

Minimums are now pinned in `docs/Gemfile` so the site stays on Active Support 7.2 (github-pages compatible) instead of jumping to 8.x.

## Test plan

- [x] `bundle lock --update` against the patched gems
- [x] `bundle exec jekyll build` succeeds with github-pages 232