### PR TITLE
Accept Metro 2 portfolio type L (lease)

### DIFF
--- a/pkg/lib/base_segment.go
+++ b/pkg/lib/base_segment.go
@@ -82,6 +82,7 @@ type BaseSegment struct {
 	//  M = Mortgage
 	//  O = Open
 	//  R = Revolving
+	//  L = Lease
 	//
 	// Refer to the Glossary of Terms for definitions of each Portfolio Type.
 	PortfolioType string `json:"portfolioType"`
@@ -815,7 +816,7 @@ func (r *BaseSegment) ValidateIdentificationNumber() error {
 // validation of portfolio type
 func (r *BaseSegment) ValidatePortfolioType() error {
 	switch r.PortfolioType {
-	case PortfolioTypeCredit, PortfolioTypeInstallment, PortfolioTypeMortgage, PortfolioTypeOpen, PortfolioTypeRevolving:
+	case PortfolioTypeCredit, PortfolioTypeInstallment, PortfolioTypeMortgage, PortfolioTypeOpen, PortfolioTypeRevolving, PortfolioTypeLease:
 		return nil
 	}
 	return utils.NewErrInvalidValueOfField("portfolio type", "base segment")
@@ -1321,7 +1322,7 @@ func (r *PackedBaseSegment) ValidateIdentificationNumber() error {
 // validation of portfolio type
 func (r *PackedBaseSegment) ValidatePortfolioType() error {
 	switch r.PortfolioType {
-	case PortfolioTypeCredit, PortfolioTypeInstallment, PortfolioTypeMortgage, PortfolioTypeOpen, PortfolioTypeRevolving:
+	case PortfolioTypeCredit, PortfolioTypeInstallment, PortfolioTypeMortgage, PortfolioTypeOpen, PortfolioTypeRevolving, PortfolioTypeLease:
 		return nil
 	}
 	return utils.NewErrInvalidValueOfField("portfolio type", "packed base segment")

--- a/pkg/lib/base_segment_test.go
+++ b/pkg/lib/base_segment_test.go
@@ -486,3 +486,11 @@ func (t *SegmentTest) TestPackedBaseSegmentWithInvalidSpecialComment(c *check.C)
 	c.Assert(err, check.Not(check.IsNil))
 	c.Assert(err.Error(), check.DeepEquals, "special comment in packed base segment has an invalid value")
 }
+
+func (t *SegmentTest) TestBaseSegmentPortfolioTypeLease(c *check.C) {
+	segment := &BaseSegment{}
+	_, err := segment.Parse(t.sampleBaseSegment, true)
+	c.Assert(err, check.IsNil)
+	segment.PortfolioType = PortfolioTypeLease
+	c.Assert(segment.ValidatePortfolioType(), check.IsNil)
+}

--- a/pkg/lib/constants.go
+++ b/pkg/lib/constants.go
@@ -20,6 +20,8 @@ const (
 	PortfolioTypeOpen = "O"
 	// type of portfolio, Revolving
 	PortfolioTypeRevolving = "R"
+	// type of portfolio, Lease
+	PortfolioTypeLease = "L"
 	// duration of credit extended, Line of Credit
 	TermsDurationCredit = "LOC"
 	// duration of credit extended, Open


### PR DESCRIPTION
## What

Allows portfolio type **`L` (Lease)** on the base and packed segments. Equifax Canada (and some other furnishers) report leases with this code; the validator previously rejected them.

## Source

Cherry-picked from [naborly/metro2@c747f38](https://github.com/naborly/metro2/commit/c747f38ee9fd6084b1853f73b3acf54e1600197f) by **michaelJeon**.

## Tests

`go test ./pkg/lib/ ./pkg/file/ ./cmd/metro2/` passes.